### PR TITLE
more efficient math

### DIFF
--- a/Wave.qml
+++ b/Wave.qml
@@ -27,7 +27,7 @@ Rectangle {
 	y: realY-(size/2)
 
 	property real size: 0
-	property real diameter: 2*(Math.sqrt(Math.pow(Math.max(x, parent.width - x), 2) + Math.pow(Math.max(y, parent.height - y), 2)))
+	property real diameter: 2*Math.sqrt(Math.pow(Math.max(x, parent.width - x), 2) + Math.pow(Math.max(y, parent.height - y), 2))
 
 	signal finished
 


### PR DESCRIPTION
/!\ this is only correct if x is always comprised between 0 and width, and y between 0 and height

(if this is not certain to be the case, tell me, there could still be ways to make the math more efficient)
