### PR TITLE
added LGPL licensed implementation of the newObject to the project

### DIFF
--- a/PageStack.qml
+++ b/PageStack.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import QtQuick 2.0
-import "../qml-extras/utils.js" as Utils
+import "js/utils.js" as Utils
 
 Item {
     id: pageStack

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,31 @@
+/*
+ * QML Material - An application framework implementing Material Design.
+ * Copyright (C) 2014 Michael Spencer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+function newObject(path, args, parent) {
+    var componentArguments = (args === undefined || args === null) ? {} : args
+    var componentParent = (parent === undefined || parent === null) ? null : parent
+    var component = Qt.createComponent(path);
+
+    if (component.status == Component.Error) {
+        throw("Unable to load object: %1:'%2'"
+            .arg(path)
+            .arg(component.errorString()));
+    }
+
+    return component.createObject(componentParent, componentArguments);
+}

--- a/qml-material.pro
+++ b/qml-material.pro
@@ -2,6 +2,7 @@ TEMPLATE = subdirs
 
 deployment.files += qmldir \
                     *.qml \
+                    js \
                     icons \
                     fonts \
                     ListItems \


### PR DESCRIPTION
This is a **very** questionable change.  Since this module is LGPL and the javascript it was including was GPL there is a risk that if someone wishes to use this module in a closed source application they would be in violation of the javascript's license without even knowing it.  To simplify matters I assigned the copyright to you since it is so trivial and I assume it will be extended.  I do not want any license changes on your part to be encumbered by seeking my permission at some future date.

There is a functional change in that I added some more error checking as well as being able to throw a reasonable error on a component failure.  I also make sure there is a valid args object to pass in so that users of the API have the option of just giving the component name to create the object.  I would argue though that parent should not be optional since if there is no parent given then the created objects lifetime is altered to be destroyed when it's last reference is lost instead of when the contained parent is destroyed.  That is just opinion so I am not too concerned.
