### PR TITLE
Align elevation shadows correctly when View is rotated

### DIFF
--- a/modules/Material/View.qml
+++ b/modules/Material/View.qml
@@ -158,6 +158,7 @@ Item {
         anchors.fill: parent
         color: Qt.tint(backgroundColor, tintColor)
         radius: item.radius
+        antialiasing: parent.rotation ? true : false
 
         clip: true
 


### PR DESCRIPTION
As the material design allows the material to move on any axis and rotate around these modifications align the elevation shadows according to the View rotation
