### PR TITLE
Subclass action

### DIFF
--- a/modules/Material/Action.qml
+++ b/modules/Material/Action.qml
@@ -15,7 +15,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
- import QtQuick 2.0
+import QtQuick 2.0
+import QtQuick.Controls 1.2 as Controls
 
 /*!
    \qmltype Action
@@ -24,19 +25,8 @@
 
    \brief Represents an action shown in an action bar, context menu, or list.
  */
-QtObject {
+Controls.Action {
     id: action
-
-	/*!
-	   The text displayed for the action.
-	 */
-    property string name
-
-    /*!
-       The icon displayed for the action. This can be a Material Design icon or an icon from
-       FontAwesome. See \l Icon from more details.
-     */
-    property string iconName
 
     /*!
       A short summary of the action, which may be displayed depending on the UI showing the
@@ -56,14 +46,4 @@ QtObject {
      */
     property bool visible: true
 
-    /*!
-       Set to \c false to disable the action.
-     */
-    property bool enabled: true
-
-	/*!
-	   Called when the UI representing the action is triggered. \c caller contains the UI element
-	   that triggered the action.
-	 */
-    signal triggered(var caller)
 }

--- a/modules/Material/ActionBar.qml
+++ b/modules/Material/ActionBar.qml
@@ -36,12 +36,12 @@ Item {
     implicitHeight: Device.formFactor === "mobile"
                     ? units.dp(48) : Device.formFactor == "tablet"
                       ? units.dp(56) : units.dp(64)
-
+/*
     anchors {
         left: parent.left
         right: parent.right
     }
-
+*/
     /*!
        \internal
        The page holding this \c ActionBar

--- a/modules/Material/CardPage.qml
+++ b/modules/Material/CardPage.qml
@@ -96,9 +96,6 @@ Page {
                         id: iconAction
 
                         property Action action: actions[index]
-
-                        name: action.iconName
-                        //color:
                         size: name == "content/add" ? units.dp(30) : units.dp(27)
                         anchors.verticalCenter: parent ? parent.verticalCenter : undefined
 

--- a/modules/Material/IconAction.qml
+++ b/modules/Material/IconAction.qml
@@ -46,7 +46,6 @@ Icon {
         height: Math.max(parent.height, units.dp(48))
 
         onClicked: {
-            //ink.focused = true
             icon.triggered()
         }
     }

--- a/modules/Material/Page.qml
+++ b/modules/Material/Page.qml
@@ -38,7 +38,7 @@ Rectangle {
 
     property list<Action> actions
     property Action backAction: Action {
-        name: "Back"
+        text: "Back"
         iconName: "navigation/arrow_back"
         onTriggered: pageStack.pop()
         visible: showBackButton

--- a/modules/Material/Page.qml
+++ b/modules/Material/Page.qml
@@ -27,8 +27,11 @@ Rectangle {
 
     ActionBar {
         id: __actionBar
-
         page: page
+        anchors {
+            left: page.left
+            right: page.right
+        }
     }
 
     property Item pageStack
@@ -43,7 +46,7 @@ Rectangle {
 
     anchors.fill: parent
 
-    property bool currentPage: pageStack.currentPage == page
+    property bool currentPage: pageStack ? pageStack.currentPage === page : false
 
     property bool dynamic: false
 

--- a/modules/Material/Transitions/PageTransition.qml
+++ b/modules/Material/Transitions/PageTransition.qml
@@ -20,11 +20,16 @@ import Material 0.1
 
 Item {
     id: trans
-    anchors.fill: parent
 
     property PageStack pageStack
-
-    parent: pageStack
+    onPageStackChanged: {
+        if ( pageStack ) {
+            anchors.left = pageStack.left;
+            anchors.right = pageStack.right;
+            anchors.top = pageStack.top;
+            anchors.bottom = pageStack.bottom;
+        }
+    }
 
     default property alias content: transView.children
 


### PR DESCRIPTION
This moves the Action to be an extension of QtControls Action.  The controls action is not completely aware of the UI state, so we still need a few properties specific to Material.
