### PR TITLE
Change font loading order to make sure they can coexist. Add proper casing for button text.

### DIFF
--- a/modules/Material/Label.qml
+++ b/modules/Material/Label.qml
@@ -106,6 +106,8 @@ Text {
         }
     }
 
+    font.capitalization: style == "button" ? Font.AllUppercase : Font.MixedCase
+
     color: Theme.light.textColor
 
 

--- a/modules/Material/Theme.qml
+++ b/modules/Material/Theme.qml
@@ -113,13 +113,15 @@ Object {
     }
 
     // TODO: Load all the fonts!
-    FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-Regular.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-BlackItalic.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-Black.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-Bold.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-BoldItalic.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/RobotoCondensed-Bold.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/RobotoCondensed-BoldItalic.ttf")}
+    FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-Medium.ttf")}
+    FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-MediumItalic.ttf")}
+    FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-Regular.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/RobotoCondensed-Italic.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/RobotoCondensed-Light.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/RobotoCondensed-LightItalic.ttf")}
@@ -127,10 +129,7 @@ Object {
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-Italic.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-Light.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-LightItalic.ttf")}
-    FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-Medium.ttf")}
-    FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-MediumItalic.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-Thin.ttf")}
     FontLoader {source: Qt.resolvedUrl("fonts/roboto/Roboto-ThinItalic.ttf")}
-
 
 }


### PR DESCRIPTION
Looks like thanks to a bug in QT, https://bugreports.qt.io/browse/QTBUG-42090 - the Roboto medium / bold / black fonts were overwriting the normal fonts. This was causing normal usages of the font to come out as DemiBold. Also, our button font was not being capitalized as the material guidelines say they should.

I fixed the capitalization issue, and modified our font loading order so that everything seems to be correct now.

Before:
![image](https://cloud.githubusercontent.com/assets/1914540/5763606/cd327922-9cb9-11e4-9db9-401f1b727b61.png)

After:
![image](https://cloud.githubusercontent.com/assets/1914540/5763609/d2cb1b8c-9cb9-11e4-968a-fa2754447fdb.png)

