### PR TITLE
Fix toolbar default color to be the Theme's Primary Color

### DIFF
--- a/modules/Material/ApplicationWindow.qml
+++ b/modules/Material/ApplicationWindow.qml
@@ -82,7 +82,7 @@ Controls.ApplicationWindow {
     toolBar: Toolbar {
         id: __toolbar
         width: parent.width
-        backgroundColor: Theme.primaryDarkColor
+        backgroundColor: Theme.primaryColor
     }
 
     PageStack {


### PR DESCRIPTION
Looks like a recent merge changed the Toolbar to use the primaryDarkColor by default. The toolbar should be the primaryColor. The primaryDarkColor only comes into play with the status bar.

Ref: http://www.google.com/design/spec/style/color.html#color-ui-color-application

![image](https://cloud.githubusercontent.com/assets/1914540/5802132/00d95a6c-9fc0-11e4-94e7-afc1a0ca9960.png)
