### PR TITLE
Change mouse cursor to IBeamCursor when over the text input in the new TextField component.

### DIFF
--- a/modules/Material/TextField.qml
+++ b/modules/Material/TextField.qml
@@ -94,6 +94,12 @@ FocusScope {
 
       onAccepted: field.accepted()
       onEditingFinished: field.editingFinished()
+
+      MouseArea {
+          anchors.fill: parent
+          cursorShape: Qt.IBeamCursor
+          acceptedButtons: Qt.NoButton
+      }
    }
 
    Label {


### PR DESCRIPTION
The new TextField wasn't changing the mouse cursor to the platforms IBeamCursor on hover, as expected. This should fix it.