### PR TITLE
Fix color mismatch in slider.

### DIFF
--- a/modules/Material/Slider.qml
+++ b/modules/Material/Slider.qml
@@ -74,7 +74,7 @@ Controls.Slider {
                 Rectangle {
                     implicitHeight: parent.height / 2
                     implicitWidth: parent.width / 2
-                    color: Theme.primaryColor
+                    color: control.color
                     anchors.right: parent.right
                     anchors.bottom: parent.bottom
                     antialiasing: true


### PR DESCRIPTION
Looks like the cleanup of the slider control missed a spot.

Before:
![image](https://cloud.githubusercontent.com/assets/1914540/5964950/4618a016-a7c6-11e4-8da9-a16c2c4e5e46.png)

After:

![image](https://cloud.githubusercontent.com/assets/1914540/5964985/8edec6c2-a7c6-11e4-9f3e-848b80de591c.png)
