### PR TITLE
Fix the dialog behavior to act more like a standard Material dialog - Add dialog to demo

### DIFF
--- a/demo/DialogDemo.qml
+++ b/demo/DialogDemo.qml
@@ -1,0 +1,112 @@
+import QtQuick 2.0
+import QtQuick.Controls 1.2 as QuickControls
+import Material 0.1
+import Material.Extras 0.1
+
+Item {
+    property string currentText
+
+    Dialog {
+        id: actionableDialog
+        title: "Change Text"
+        hasActions: true
+
+        TextField {
+            id: optionText
+            text: currentText
+            anchors.horizontalCenter: parent.horizontalCenter
+            placeholderText: "New Option to Confirm"
+        }
+
+        onAccepted: {
+            currentText = optionText.text
+        }
+    }
+
+    Dialog {
+        id: scrollingDialog
+        title: "Choose Size"
+        hasActions: false
+
+        Flickable {
+            id: mainFlick
+            z: parent.z + 1
+            width: units.dp(200)
+            height: units.dp(200)
+            clip: true
+            interactive: contentHeight > height
+            contentHeight: mainCol.height
+            contentWidth: width
+            Column {
+                id: mainCol
+                QuickControls.ExclusiveGroup {
+                    id: optionGroup
+                }
+                RadioButton {
+                    text: "Small"
+                    checked: true
+                    exclusiveGroup: optionGroup
+                }
+                RadioButton {
+                    text: "Normal"
+                    exclusiveGroup: optionGroup
+                }
+                RadioButton {
+                    text: "Big"
+                    exclusiveGroup: optionGroup
+                }
+                RadioButton {
+                    text: "Gigantic"
+                    exclusiveGroup: optionGroup
+                }
+                RadioButton {
+                    text: "Enourmous"
+                    exclusiveGroup: optionGroup
+                }
+                RadioButton {
+                    text: "Titanic"
+                    exclusiveGroup: optionGroup
+                }
+                RadioButton {
+                    text: "Humongous"
+                    exclusiveGroup: optionGroup
+                }
+                RadioButton {
+                    text: "Ginourmous"
+                    exclusiveGroup: optionGroup
+                }
+            }
+        }
+
+        Scrollbar {
+            flickableItem: mainFlick
+        }
+    }
+
+    Column {
+        anchors.centerIn: parent
+        spacing: units.dp(20)
+
+        Button {
+            text: "Show Action Dialog"
+            anchors.horizontalCenter: parent.horizontalCenter
+            elevation: 1
+            onClicked: {
+                actionableDialog.show()
+            }
+        }
+
+        Button {
+            text: "Show Scrolling Dialog"
+            anchors.horizontalCenter: parent.horizontalCenter
+            elevation: 1
+            onClicked: {
+                scrollingDialog.show()
+            }
+        }
+
+        Label {
+            text: currentText
+        }
+    }
+}

--- a/demo/main.qml
+++ b/demo/main.qml
@@ -11,7 +11,7 @@ ApplicationWindow {
 
     initialPage: page
 
-    property var components: ["Button", "Switch", "Radio Button", "Slider", "Progress Bar", "Icon", "TextField", "Page Stack", "List Items"]
+    property var components: ["Button", "Switch", "Radio Button", "Slider", "Progress Bar", "Icon", "TextField", "Page Stack", "List Items", "Dialog"]
     property string selectedComponent: components[0]
 
     Page {

--- a/modules/Material/ApplicationWindow.qml
+++ b/modules/Material/ApplicationWindow.qml
@@ -103,7 +103,8 @@ Controls.ApplicationWindow {
         onPopped: __toolbar.pop(  )
     }
 
-    Item {
+
+    Rectangle {
         id: overlayLayer
         objectName: "overlayLayer"
 
@@ -111,12 +112,32 @@ Controls.ApplicationWindow {
         z: 100
 
         property Item currentOverlay
+        color: "transparent"
+
+        states: State {
+            name: "ShowState"
+            when: overlayLayer.currentOverlay != null
+
+            PropertyChanges {
+                target: overlayLayer
+                color: currentOverlay.backdropColor
+            }
+        }
+
+        transitions: Transition {
+            ColorAnimation {
+                duration: 300
+                easing.type: Easing.InOutQuad
+            }
+
+        }
 
         MouseArea {
             anchors.fill: parent
             enabled: overlayLayer.currentOverlay != null
             hoverEnabled: enabled
             onClicked: overlayLayer.currentOverlay.close()
+            onWheel: wheel.accepted = true
         }
     }
 

--- a/modules/Material/Dropdown.qml
+++ b/modules/Material/Dropdown.qml
@@ -2,87 +2,10 @@ import QtQuick 2.0
 import Material 0.1
 import Material.Extras 0.1
 
-Item {
+Popover {
     id: dropdown
 
-    Component.onCompleted: {
-        parent = Utils.findRootChild(dropdown, "overlayLayer")
-    }
-
-    property int anchor: Item.TopRight
-
-    property bool showing
-
-    default property alias content: view.content
-
-    onShowingChanged: {
-        if (showing)
-            parent.currentOverlay = dropdown
-        else
-            parent.currentOverlay = null
-    }
-
-    function open(caller, offsetX, offsetY) {
-        var position = caller.mapToItem(dropdown.parent, 0, 0)
-
-        if (__internal.left) {
-            dropdown.x = position.x
-        } else {
-            dropdown.x = position.x + caller.width - dropdown.width
-        }
-
-        if (__internal.top) {
-            dropdown.y = position.y
-        } else {
-            dropdown.y = position.y + caller.height - dropdown.height
-        }
-
-        dropdown.x += offsetX
-        dropdown.y += offsetY
-
-        showing = true
-    }
-
-    function close() {
-        showing = false
-    }
-
-    QtObject {
-        id: __internal
-
-        property bool left: dropdown.anchor == Item.Left || dropdown.anchor == Item.TopLeft ||
-                            dropdown.anchor == Item.BottomLeft
-        property bool right: dropdown.anchor == Item.Right || dropdown.anchor == Item.TopRight ||
-                             dropdown.anchor == Item.BottomRight
-        property bool top: dropdown.anchor == Item.Top || dropdown.anchor == Item.TopLeft ||
-                           dropdown.anchor == Item.TopRight
-        property bool bottom: dropdown.anchor == Item.Bottom || dropdown.anchor == Item.BottomLeft ||
-                              dropdown.anchor == Item.BottomRight
-    }
-
-    state: showing ? "open" : "closed"
-
-    states: [
-        State {
-            name: "closed"
-            PropertyChanges {
-                target: view
-                opacity: 0
-                width: 0
-                height: 0
-            }
-        },
-
-        State {
-            name: "open"
-            PropertyChanges {
-                target: view
-                opacity: 1
-                width: dropdown.width
-                height: dropdown.height
-            }
-        }
-    ]
+    anchor: Item.TopRight
 
     transitions: [
         Transition {
@@ -90,7 +13,7 @@ Item {
             to: "closed"
 
             NumberAnimation {
-                target: view
+                target: internalView
                 property: "opacity"
                 duration: 400
                 easing.type: Easing.InOutQuad
@@ -103,7 +26,7 @@ Item {
                 }
 
                 NumberAnimation {
-                    target: view
+                    target: internalView
                     property: "width"
                     duration: 200
                     easing.type: Easing.InOutQuad
@@ -111,7 +34,7 @@ Item {
             }
 
             NumberAnimation {
-                target: view
+                target: internalView
                 property: "height"
                 duration: 400
                 easing.type: Easing.InOutQuad
@@ -123,38 +46,26 @@ Item {
             to: "open"
 
             NumberAnimation {
-                target: view
+                target: internalView
                 property: "opacity"
                 duration: 400
                 easing.type: Easing.InOutQuad
             }
 
             NumberAnimation {
-                target: view
+                target: internalView
                 property: "width"
                 duration: 200
                 easing.type: Easing.InOutQuad
             }
 
             NumberAnimation {
-                target: view
+                target: internalView
                 property: "height"
                 duration: 400
                 easing.type: Easing.InOutQuad
             }
         }
     ]
-
-    View {
-        id: view
-
-        elevation: 2
-        radius: units.dp(2)
-
-        anchors.left: __internal.left ? dropdown.left : undefined
-        anchors.right: __internal.right ? dropdown.right : undefined
-        anchors.top: __internal.top ? dropdown.top : undefined
-        anchors.bottom: __internal.bottom ? dropdown.bottom : undefined
-    }
 }
 

--- a/modules/Material/Popover.qml
+++ b/modules/Material/Popover.qml
@@ -1,0 +1,117 @@
+import QtQuick 2.0
+import Material 0.1
+import Material.Extras 0.1
+
+Item {
+    id: dropdown
+
+    Component.onCompleted: {
+        parent = Utils.findRootChild(dropdown, "overlayLayer")
+    }
+
+    property int anchor: Item.TopRight
+
+    property bool showing
+    property color backdropColor: "transparent"
+
+    default property alias content: view.content
+    property alias internalView: view
+
+    onShowingChanged: {
+        if (showing)
+        {
+            parent.currentOverlay = dropdown
+        }
+        else
+            parent.currentOverlay = null
+    }
+
+    function open(caller, offsetX, offsetY) {
+        if(typeof offsetX === "undefined")
+            offsetX = 0
+
+        if(typeof offsetY === "undefined")
+            offsetY = 0
+
+        var position = caller.mapToItem(dropdown.parent, 0, 0)
+
+        if (__internal.left) {
+            dropdown.x = position.x
+        }
+        else if (__internal.center) {
+            dropdown.x = caller.width / 2 - dropdown.width / 2
+        }
+        else {
+            dropdown.x = position.x + caller.width - dropdown.width
+        }
+
+        if (__internal.top) {
+            dropdown.y = position.y
+        }
+        else if (__internal.center){
+            dropdown.y = caller.height / 2 - dropdown.height / 2
+        } else {
+            dropdown.y = position.y + caller.height - dropdown.height
+        }
+
+        dropdown.x += offsetX
+        dropdown.y += offsetY
+
+        showing = true
+    }
+
+    function close() {
+        showing = false
+    }
+
+    QtObject {
+        id: __internal
+
+        property bool left: dropdown.anchor == Item.Left || dropdown.anchor == Item.TopLeft ||
+                            dropdown.anchor == Item.BottomLeft
+        property bool right: dropdown.anchor == Item.Right || dropdown.anchor == Item.TopRight ||
+                             dropdown.anchor == Item.BottomRight
+        property bool top: dropdown.anchor == Item.Top || dropdown.anchor == Item.TopLeft ||
+                           dropdown.anchor == Item.TopRight
+        property bool bottom: dropdown.anchor == Item.Bottom || dropdown.anchor == Item.BottomLeft ||
+                              dropdown.anchor == Item.BottomRight
+        property bool center: dropdown.anchor == Item.Center
+    }
+
+    state: showing ? "open" : "closed"
+
+    states: [
+        State {
+            name: "closed"
+            PropertyChanges {
+                target: view
+                opacity: 0
+                width: 0
+                height: 0
+            }
+        },
+
+        State {
+            name: "open"
+            PropertyChanges {
+                target: view
+                opacity: 1
+                width: dropdown.width
+                height: dropdown.height
+            }
+        }
+    ]
+
+    View {
+        id: view
+        elevation: 2
+        radius: units.dp(2)
+        anchors.left: __internal.left ? dropdown.left : undefined
+        anchors.right: __internal.right ? dropdown.right : undefined
+        anchors.top: __internal.top ? dropdown.top : undefined
+        anchors.bottom: __internal.bottom ? dropdown.bottom : undefined
+        anchors.horizontalCenter: __internal.center ? dropdown.horizontalCenter : undefined
+        anchors.verticalCenter: __internal.center ? dropdown.verticalCenter : undefined
+    }
+}
+

--- a/modules/Material/Toolbar.qml
+++ b/modules/Material/Toolbar.qml
@@ -153,6 +153,7 @@ View {
 
     Row {
         id: windowControls
+        visible: clientSideDecorations
         anchors {
             verticalCenter: stack.verticalCenter
             right: parent.right

--- a/modules/Material/Toolbar.qml
+++ b/modules/Material/Toolbar.qml
@@ -153,7 +153,6 @@ View {
 
     Row {
         id: windowControls
-
         anchors {
             verticalCenter: stack.verticalCenter
             right: parent.right

--- a/modules/Material/View.qml
+++ b/modules/Material/View.qml
@@ -161,7 +161,6 @@ Item {
         color: Qt.tint(backgroundColor, tintColor)
         radius: item.radius
         antialiasing: parent.rotation || radius > 0 ? true : false
-
         clip: true
 
         Behavior on color {

--- a/modules/Material/qmldir
+++ b/modules/Material/qmldir
@@ -23,6 +23,7 @@ Object 0.1 Object.qml
 Page 0.1 Page.qml
 PageStack 0.1 PageStack.qml
 singleton Palette 0.1 Palette.qml
+Popover 0.1 Popover.qml
 ProgressBar 0.1 ProgressBar.qml
 RadioButton 0.1 RadioButton.qml
 Sidebar 0.1 Sidebar.qml


### PR DESCRIPTION
This fixes some of the dialog behavior to behave more in-line with how material dialogs work.
When shown, they should shadow anything in the background, and center in the UI. Clicking any area outside of the dialog effectively dismisses the dialog. Added the ability to make the dialog have no confirmation button options either, for use with simple radio-button type option dialogs.

Included is an example in the demo project.

![image](https://cloud.githubusercontent.com/assets/1914540/6042851/0bb9f8fe-ac56-11e4-81df-9f06d7a0a272.png)

![image](https://cloud.githubusercontent.com/assets/1914540/6042855/173bdb2a-ac56-11e4-8b04-5d40595be758.png)

Also I fixed up a WIP client side decoration that was showing no matter what.

