### PR TITLE
only show the window close button for client-side decorated windows

### DIFF
--- a/modules/Material/Toolbar.qml
+++ b/modules/Material/Toolbar.qml
@@ -153,6 +153,7 @@ View {
 
     Row {
         id: windowControls
+        visible: clientSideDecorations
 
         anchors {
             verticalCenter: stack.verticalCenter


### PR DESCRIPTION
even though I am not a big fan of this approach. The [documentation](http://doc.qt.io/qt-5/qml-qtquick-item.html#visible-prop) says the item will still receive key events but I see it used in other places as well. Maybe we should find a general solution to this problem (items that only exist under a certain condition).