### PR TITLE
Create new MenuField widget

### DIFF
--- a/modules/Material/ListItems/Standard.qml
+++ b/modules/Material/ListItems/Standard.qml
@@ -24,6 +24,7 @@ BaseListItem {
     height: units.dp(48)
 
     property alias text: label.text
+    readonly property Item itemLabel: label
     property alias valueText: valueLabel.text
 
     property alias action: actionItem.children

--- a/modules/Material/MenuField.qml
+++ b/modules/Material/MenuField.qml
@@ -21,23 +21,17 @@ Item {
 
    property bool floatingLabel: false
    property bool hasError: false
-   property alias hasHelperText: __internal.showHelperText
+   property bool hasHelperText: helperText.length > 0
 
    readonly property rect inputRect: Qt.rect(spinBox.x, spinBox.y, spinBox.width, spinBox.height)
 
-   implicitHeight: __internal.showHelperText ? helperTextLabel.y + helperTextLabel.height + units.dp(4)
-                          : underline.y + units.dp(8)
+   implicitHeight: hasHelperText ? helperTextLabel.y + helperTextLabel.height + units.dp(4)
+                                  : underline.y + units.dp(8)
    implicitWidth: spinBox.width
 
    activeFocusOnTab: true
 
    signal itemSelected(int index)
-
-   QtObject {
-       id: __internal
-
-       property bool showHelperText: helperText.length > 0
-   }
 
    Ink {
       anchors.fill: parent
@@ -55,7 +49,7 @@ Item {
       y: {
          if( !floatingLabel )
             return units.dp(16)
-         if( floatingLabel && !__internal.showHelperText )
+         if( floatingLabel && !hasHelperText )
             return units.dp(40)
          return units.dp(28)
       }
@@ -150,7 +144,7 @@ Item {
 
    Label {
       id: helperTextLabel
-      visible: __internal.showHelperText
+      visible: hasHelperText
       font.pixelSize: units.dp(12)
       color: field.hasError ? field.errorColor : Qt.darker(Theme.light.hintColor)
       anchors {

--- a/modules/Material/MenuField.qml
+++ b/modules/Material/MenuField.qml
@@ -91,7 +91,7 @@ Item {
             width: menu.width
             height: menu.height
             interactive: true
-            model: ["Apple","Orange","Banana","Grapefruit","Kiwi","Lemon","Watermelon"]
+            model: []
             delegate: Standard {
                id: delegateItem
                text: modelData

--- a/modules/Material/MenuField.qml
+++ b/modules/Material/MenuField.qml
@@ -65,7 +65,6 @@ Item {
          height: parent.height
          width: parent.width
 
-         Item { Layout.minimumWidth: units.dp(16) }
          Label {
             id: label
             Layout.fillWidth: true

--- a/modules/Material/MenuField.qml
+++ b/modules/Material/MenuField.qml
@@ -1,0 +1,168 @@
+import QtQuick 2.2
+import QtQuick.Layouts 1.1
+
+import Material 0.1
+import Material.ListItems 0.1
+
+
+Item {
+   id: field
+
+   property color accentColor: Theme.accentColor
+   property color errorColor: "#F44336"
+
+   property alias model: listView.model
+   readonly property string selectedText: listView.currentItem.text
+   property alias selectedIndex: listView.currentIndex
+   property int maxVisibleItems: 4
+
+   property alias placeholderText: fieldPlaceholder.text
+   property alias helperText: helperTextLabel.text
+
+   property bool floatingLabel: false
+   property bool hasError: false
+   property alias hasHelperText: __internal.showHelperText
+
+   readonly property rect inputRect: Qt.rect(spinBox.x, spinBox.y, spinBox.width, spinBox.height)
+
+   implicitHeight: __internal.showHelperText ? helperTextLabel.y + helperTextLabel.height + units.dp(4)
+                          : underline.y + units.dp(8)
+   implicitWidth: spinBox.width
+
+   activeFocusOnTab: true
+
+   signal itemSelected(int index)
+
+   QtObject {
+       id: __internal
+
+       property bool showHelperText: helperText.length > 0
+   }
+
+   Ink {
+      anchors.fill: parent
+      onClicked: {
+         listView.positionViewAtIndex(listView.currentIndex, ListView.Center)
+         var offset = listView.currentItem.itemLabel.mapToItem(menu, 0, 0)
+         menu.open(label, -offset.x, -offset.y)
+      }
+   }
+
+   Item {
+      id: spinBox
+      height: units.dp(24)
+      width: spinBoxContents.implicitWidth
+      y: {
+         if( !floatingLabel )
+            return units.dp(16)
+         if( floatingLabel && !__internal.showHelperText )
+            return units.dp(40)
+         return units.dp(28)
+      }
+
+      RowLayout {
+         id: spinBoxContents
+         height: parent.height
+         width: parent.width
+
+         Item { Layout.minimumWidth: units.dp(16) }
+         Label {
+            id: label
+            Layout.fillWidth: true
+            anchors.verticalCenter: parent.verticalCenter
+            text: listView.currentItem.text
+            style: "subheading"
+            elide: Text.ElideRight
+         }
+         Icon {
+            id: dropDownIcon
+            anchors.verticalCenter: label.verticalCenter
+            name: "navigation/arrow_drop_down"
+            Layout.maximumWidth: units.dp(20)
+            fillMode: Image.PreserveAspectFit
+         }
+      }
+
+      Dropdown {
+         id: menu
+         anchor: Item.TopLeft
+         width: Math.max(units.dp(56*2), Math.min(spinBox.width - 2 * x, listView.contentWidth))
+         //If there are more than max items, show an extra half item so it's clear the user can scroll
+         height: Math.min(maxVisibleItems*units.dp(48) + units.dp(24), listView.contentHeight)
+
+         Scrollbar {
+            flickableItem: listView
+         }
+         ListView {
+            id: listView
+            width: menu.width
+            height: menu.height
+            interactive: true
+            model: ["Apple","Orange","Banana","Grapefruit","Kiwi","Lemon","Watermelon"]
+            delegate: Standard {
+               id: delegateItem
+               text: modelData
+
+               onTriggered: {
+                  itemSelected(index)
+                  listView.currentIndex = index
+                  menu.close()
+               }
+            }
+         }
+      }
+   }
+
+   Label {
+      id: fieldPlaceholder
+
+      text: field.placeholderText
+      visible: floatingLabel
+
+      font.pixelSize: units.dp(12)
+
+      anchors.bottom: spinBox.top
+      anchors.bottomMargin: units.dp(8)
+
+      color: Theme.light.hintColor
+   }
+
+   Rectangle {
+      id: underline
+      color: field.hasError ? field.errorColor : field.activeFocus ? field.accentColor : Theme.light.hintColor
+
+      height: field.activeFocus ? units.dp(2) : units.dp(1)
+
+      anchors {
+         left: parent.left
+         right: parent.right
+         top: spinBox.bottom
+         topMargin: units.dp(8)
+      }
+
+      Behavior on height {
+         NumberAnimation { duration: 200 }
+      }
+
+      Behavior on color {
+         ColorAnimation { duration: 200 }
+      }
+   }
+
+   Label {
+      id: helperTextLabel
+      visible: __internal.showHelperText
+      font.pixelSize: units.dp(12)
+      color: field.hasError ? field.errorColor : Qt.darker(Theme.light.hintColor)
+      anchors {
+         left: parent.left
+         right: parent.right
+         top: underline.top
+         topMargin: units.dp(4)
+      }
+
+      Behavior on color {
+         ColorAnimation { duration: 200 }
+      }
+   }
+}

--- a/modules/Material/qmldir
+++ b/modules/Material/qmldir
@@ -18,6 +18,7 @@ singleton i18n 0.1 i18n.qml
 Label 0.1 Label.qml
 MainView 0.1 MainView.qml
 singleton MaterialAnimation 0.1 MaterialAnimation.qml
+MenuField 0.1 MenuField.qml
 NavigationDrawer 0.1 NavigationDrawer.qml
 Object 0.1 Object.qml
 Page 0.1 Page.qml


### PR DESCRIPTION
A new menu field widget which implements a combo-box style menu.
This widget is intended to fit in-line with TextField widgets,
thus its internal structure and exposed properties are similar.

This component is intended to mimic the "NY" field shown here:
http://material-design.storage.googleapis.com/publish/v_2/material_ext_publish/0Bx4BSt6jniD7MHBnQlFGeFRtYTQ/components_menus_usage5.png