### PR TITLE
Fix CheckBoxDemo.qml canno be loaded

### DIFF
--- a/demo/main.qml
+++ b/demo/main.qml
@@ -11,7 +11,7 @@ ApplicationWindow {
 
     initialPage: page
 
-    property var components: ["Button", "Checkbox", "Dialog", "Forms", "Icon", "List Items", "Page Stack", "Progress Bar", "Radio Button", "Slider", "Switch", "TextField"]
+    property var components: ["Button", "CheckBox", "Dialog", "Forms", "Icon", "List Items", "Page Stack", "Progress Bar", "Radio Button", "Slider", "Switch", "TextField"]
 
     property string selectedComponent: components[0]
 


### PR DESCRIPTION
"Checkbox" is wrong in components array. It should be "CheckBox" to be able to load the qml file CheckBoxDemo.qml. 
Otherwise the error "file:///.../qml-material/modules/Material/Checkbox.qml: File name case mismatch" is encountered.