### PR TITLE
[Units] Round units.dp() return value

### DIFF
--- a/modules/Material/units.qml
+++ b/modules/Material/units.qml
@@ -64,6 +64,6 @@ Object {
        this anywhere you need to refer to distances on the screen.
      */
     function dp(number) {
-        return number*((pixelDensity*25.4)/160)*multiplier;
+        return Math.round(number*((pixelDensity*25.4)/160)*multiplier);
     }
 }


### PR DESCRIPTION
This fixes some weird visual issues when scrolling items inside a Layout and
some text fields without underline.