### PR TITLE
[ProgressCircle] Fixes animation performance

### DIFF
--- a/modules/Material/ProgressCircle.qml
+++ b/modules/Material/ProgressCircle.qml
@@ -104,13 +104,13 @@ Controls.ProgressBar {
                 from: 0
                 to: 2 * Math.PI
                 loops: Animation.Infinite
-                running: control.indeterminate
+                running: control.indeterminate && canvas.visible
                 easing.type: Easing.Linear
                 duration: 3000
             }
 
             SequentialAnimation {
-                running: control.indeterminate
+                running: control.indeterminate && canvas.visible
                 loops: Animation.Infinite
 
                 ParallelAnimation {


### PR DESCRIPTION
The animation that runs the indeterminate
mode of the progress circle was running
even when the canvas was not visible. This
was causing window performance to suffer
when moving it.