### PR TITLE
[TextField] Fixes floating label behavior on devices

### DIFF
--- a/modules/Material/TextField.qml
+++ b/modules/Material/TextField.qml
@@ -117,7 +117,7 @@ FocusScope {
       states: [
          State {
             name: "floating"
-            when: textInput.text.length > 0 && floatingLabel
+            when: textInput.displayText.length > 0 && floatingLabel
             AnchorChanges {
                target: fieldPlaceholder
                anchors.baseline: undefined
@@ -130,7 +130,7 @@ FocusScope {
          },
          State {
             name: "hidden"
-            when: textInput.text.length > 0 && !floatingLabel
+            when: textInput.displayText.length > 0 && !floatingLabel
             PropertyChanges {
                target: fieldPlaceholder
                visible: false


### PR DESCRIPTION
On devices that use a virtual keyboard, like Android, TextInput's onTextChanged signal is not fired until
editing is complete, such as when the keyboard is dismissed. This caused the floating label feature to not work properly. Using displayText gives proper behavior.