### PR TITLE
Fix Snackbar button margins, color and a little more

### DIFF
--- a/demo/ButtonDemo.qml
+++ b/demo/ButtonDemo.qml
@@ -37,7 +37,7 @@ Item {
             activeFocusOnPress: true
             anchors.horizontalCenter: parent.horizontalCenter
 
-            onClicked: snackbar.open("The text is really long")
+            onClicked: snackbar.open("The text is really very very very long")
         }
 
         Button {

--- a/modules/Material/Button.qml
+++ b/modules/Material/Button.qml
@@ -28,7 +28,7 @@ Controls.Button {
     property color textColor: Theme.lightDark(button.backgroundColor,
                                               Theme.light.textColor,
                                               Theme.dark.textColor)
-    property string context: "default" // or "dialog"
+    property string context: "default" // or "dialog" or "snackbar"
 
     style: ControlStyles.ButtonStyle {
         padding {
@@ -60,7 +60,7 @@ Controls.Button {
                 id: mouseArea
 
                 anchors.fill: parent
-                focused: control.focus && button.context != "dialog"
+                focused: control.focus && button.context != "dialog" && button.context != "snackbar"
                 focusWidth: parent.width - units.dp(30)
                 focusColor: Qt.darker(button.backgroundColor, 1.05)
 
@@ -74,9 +74,9 @@ Controls.Button {
         }
         label: Item {
             implicitHeight: Math.max(units.dp(36), label.height + units.dp(16))
-            implicitWidth: button.context == "dialog"
-                    ? Math.max(units.dp(64), label.width + units.dp(16))
-                    : Math.max(units.dp(88), label.width + units.dp(32))
+            implicitWidth: button.context == "dialog" ? Math.max(units.dp(64), label.width + units.dp(16))
+                         : button.context == "snackbar" ? label.width + units.dp(16)
+                         : Math.max(units.dp(88), label.width + units.dp(32))
 
             Label {
                 id: label

--- a/modules/Material/Button.qml
+++ b/modules/Material/Button.qml
@@ -31,6 +31,13 @@ Controls.Button {
     property string context: "default" // or "dialog"
 
     style: ControlStyles.ButtonStyle {
+        padding {
+            left: 0
+            right: 0
+            top: 0
+            bottom: 0
+        }
+
         background: View {
             radius: units.dp(2)
 

--- a/modules/Material/Snackbar.qml
+++ b/modules/Material/Snackbar.qml
@@ -24,7 +24,7 @@ View {
 	radius: fullWidth ? 0 : units.dp(2)
 	backgroundColor: "#323232"
 	height: units.dp(48)
-	width: fullWidth ? parent.width : Math.min(implicitWidth, units.dp(568))
+	width: fullWidth ? parent.width : Math.min(Math.max(implicitWidth, units.dp(288)), units.dp(568))
 	opacity: opened ? 1 : 0
 
 	implicitWidth: buttonText == "" ? snackText.paintedWidth + units.dp(48) : snackText.paintedWidth + units.dp(72) + snackButton.width

--- a/modules/Material/Snackbar.qml
+++ b/modules/Material/Snackbar.qml
@@ -58,7 +58,7 @@ View {
 	function open(text) {
 		snackbar.text = text
 		opened = true;
-		timer.start();
+		timer.restart();
 	}
 
 	Timer {

--- a/modules/Material/Snackbar.qml
+++ b/modules/Material/Snackbar.qml
@@ -48,6 +48,7 @@ View {
 	}
 
 	property string buttonText
+	property color buttonColor: Theme.accentColor
 	property string text
 	property bool opened
 	property int duration: 2000
@@ -90,7 +91,7 @@ View {
 	Button {
 		id: snackButton
 		opacity: snackbar.buttonText == "" ? 0 : 1
-		textColor: "white"
+		textColor: snackbar.buttonColor
 		text: snackbar.buttonText
 		onClicked: snackbar.clicked()
 		anchors {

--- a/modules/Material/Snackbar.qml
+++ b/modules/Material/Snackbar.qml
@@ -93,15 +93,20 @@ View {
 		opacity: snackbar.buttonText == "" ? 0 : 1
 		textColor: snackbar.buttonColor
 		text: snackbar.buttonText
+		context: "snackbar"
 		onClicked: snackbar.clicked()
 		anchors {
 			right: parent.right
 			//left: snackText.right
 			top: parent.top
 			bottom: parent.bottom
-			topMargin: units.dp(16)
-			bottomMargin: units.dp(16)
-			rightMargin: snackbar.buttonText == "" ? 0 : units.dp(24)
+
+			// Recommended button touch target is 36dp
+			topMargin: units.dp(6)
+			bottomMargin: units.dp(6)
+
+			// Normal margin is 24dp, but button itself uses 8dp margins
+			rightMargin: snackbar.buttonText == "" ? 0 : units.dp(16)
 		}
 	}
 


### PR DESCRIPTION
The result seems a little bit closer to [Material Design spec](http://www.google.com/design/spec/components/snackbars-toasts.html#snackbars-toasts-specs) and looks nicer IMO

Before:
![image](https://cloud.githubusercontent.com/assets/880882/6909010/17fb26d8-d753-11e4-8e36-6c48d9e38b92.png)

After:
![image](https://cloud.githubusercontent.com/assets/880882/6909437/44ea4792-d757-11e4-8e21-b61dedaba1d9.png)