### PR TITLE
[Dialog] Expose dialog buttons via aliases

### DIFF
--- a/modules/Material/Dialog.qml
+++ b/modules/Material/Dialog.qml
@@ -47,6 +47,9 @@ PopupBase {
     property alias title: titleLabel.text
     property alias text: textLabel.text
 
+    property alias negativeButton: negativeButton
+    property alias positiveButton: positiveButton
+
     property string negativeButtonText: "Cancel"
     property string positiveButtonText: "Ok"
 


### PR DESCRIPTION
Simply exposes the underlying negative and positive buttons through aliases so that their properties can be customized as needed by those using dialogs