### PR TITLE
[Button] Add disabled states to Button

### DIFF
--- a/demo/ButtonDemo.qml
+++ b/demo/ButtonDemo.qml
@@ -21,6 +21,13 @@ Item {
         }
 
         Button {
+            text: "Disabled Raised Button"
+            elevation: 1
+            enabled: false
+            anchors.horizontalCenter: parent.horizontalCenter
+        }
+
+        Button {
             text: "Wide Button"
 
             width: units.dp(200)

--- a/modules/Material/Button.qml
+++ b/modules/Material/Button.qml
@@ -52,13 +52,14 @@ Controls.Button {
             }
 
             backgroundColor: control.enabled || control.elevation === 0 ? button.backgroundColor
-                                : control.darkBackground ? Qt.rgba(1, 1, 1, 0.12)
-                                                         : Qt.rgba(0, 0, 0, 0.12)
+                : control.darkBackground ? Qt.rgba(1, 1, 1, 0.12)
+                : Qt.rgba(0, 0, 0, 0.12)
 
             tintColor: mouseArea.currentCircle || control.focus || control.hovered
-                    ? Qt.rgba(0,0,0, mouseArea.currentCircle
-                           ? 0.1 : button.elevation > 0 ? 0.03 : 0.05)
-                    : "transparent"
+               ? Qt.rgba(0,0,0, mouseArea.currentCircle ? 0.1
+                                : button.elevation > 0 ? 0.03
+                                : 0.05)
+               : "transparent"
 
             Ink {
                 id: mouseArea
@@ -87,8 +88,9 @@ Controls.Button {
                 anchors.centerIn: parent
                 text: control.text
                 style: "button"
-                color: control.enabled ? button.textColor : control.darkBackground ? Qt.rgba(1, 1, 1, 0.30)
-                                                                                   : Qt.rgba(0, 0, 0, 0.26)
+                color: control.enabled ? button.textColor
+                    : control.darkBackground ? Qt.rgba(1, 1, 1, 0.30)
+                    : Qt.rgba(0, 0, 0, 0.26)
             }
         }
     }

--- a/modules/Material/Button.qml
+++ b/modules/Material/Button.qml
@@ -30,6 +30,11 @@ Controls.Button {
                                               Theme.dark.textColor)
     property string context: "default" // or "dialog"
 
+    /*!
+       Set to \c true if the button is on a dark background
+     */
+    property bool darkBackground
+
     style: ControlStyles.ButtonStyle {
         background: View {
             radius: units.dp(2)
@@ -40,9 +45,15 @@ Controls.Button {
                 if (elevation > 0 && (control.focus || mouseArea.currentCircle))
                     elevation++;
 
+                if(!control.enabled)
+                    elevation = 0;
+
                 return elevation;
             }
-            backgroundColor: button.backgroundColor
+
+            backgroundColor: control.enabled || control.elevation === 0 ? button.backgroundColor
+                                : control.darkBackground ? Qt.rgba(1, 1, 1, 0.12)
+                                                         : Qt.rgba(0, 0, 0, 0.12)
 
             tintColor: mouseArea.currentCircle || control.focus || control.hovered
                     ? Qt.rgba(0,0,0, mouseArea.currentCircle
@@ -76,7 +87,8 @@ Controls.Button {
                 anchors.centerIn: parent
                 text: control.text
                 style: "button"
-                color: button.textColor
+                color: control.enabled ? button.textColor : control.darkBackground ? Qt.rgba(1, 1, 1, 0.30)
+                                                                                   : Qt.rgba(0, 0, 0, 0.26)
             }
         }
     }


### PR DESCRIPTION
Material design has specific coloring for disabled buttons. This updates the button to
follow the spec.

![image](https://cloud.githubusercontent.com/assets/1914540/6930293/da3dc7ce-d7cf-11e4-873c-c4ebb689853d.png)

![image](https://cloud.githubusercontent.com/assets/1914540/6930310/0b19034a-d7d0-11e4-9925-f0d46e2e81bd.png)

And disabled buttons now in the demo:

![image](https://cloud.githubusercontent.com/assets/1914540/6930304/f02d2c64-d7cf-11e4-99b8-e5484a3d82dd.png)
