### PR TITLE
[RadioButton] Fixup RadioButton selection, add toggle ability, update demo

### DIFF
--- a/demo/RadioButtonDemo.qml
+++ b/demo/RadioButtonDemo.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.0
 import QtQuick.Layouts 1.1
+import QtQuick.Controls 1.2 as QuickControls
 import Material 0.1
 
 ColumnLayout {
@@ -20,10 +21,9 @@ ColumnLayout {
                 anchors.centerIn: parent
                 rowSpacing: units.dp(20)
                 columnSpacing: units.dp(20)
-                columns: 3
+                columns: 2
 
-                // Empty filler
-                Item { width: 1; height: 1 }
+                QuickControls.ExclusiveGroup { id: optionGroup }
 
                 Label {
                     Layout.alignment : Qt.AlignHCenter
@@ -37,15 +37,12 @@ ColumnLayout {
                     color: index == 0 ? Theme.light.textColor : Theme.dark.textColor
                 }
 
-                Label {
-                    text: "On"
-                    color: index == 0 ? Theme.light.textColor : Theme.dark.textColor
-                }
-
                 RadioButton {
                     checked: true
-                    text: "Selected"
+                    text: "Option 1"
                     darkBackground: index == 1
+                    canToggle: true
+                    exclusiveGroup: optionGroup
                 }
 
                 RadioButton {
@@ -55,14 +52,11 @@ ColumnLayout {
                     darkBackground: index == 1
                 }
 
-                Label {
-                    text: "Off"
-                    color: index == 0 ? Theme.light.textColor : Theme.dark.textColor
-                }
-
                 RadioButton {
-                    text: "Selected"
+                    text: "Option 2"
                     darkBackground: index == 1
+                    canToggle: true
+                    exclusiveGroup: optionGroup
                 }
 
                 RadioButton {

--- a/modules/Material/RadioButton.qml
+++ b/modules/Material/RadioButton.qml
@@ -35,6 +35,11 @@ Controls.RadioButton {
      */
     property bool darkBackground
 
+    /*!
+       Set to \c true if the radio button can be toggled from checked to unchecked
+     */
+    property bool canToggle
+
     style: ControlStyles.RadioButtonStyle {
         label :Label {
             text: control.text
@@ -99,6 +104,7 @@ Controls.RadioButton {
     }
 
     Ink {
+        id: inkArea
         anchors {
             left: parent.left
             leftMargin: units.dp(4)
@@ -108,9 +114,26 @@ Controls.RadioButton {
         width: units.dp(40)
         height: units.dp(40)
         color: radioButton.checked ? Theme.alpha(radioButton.color, 0.20) : Qt.rgba(0,0,0,0.1)
-        onClicked: radioButton.checked = !radioButton.checked
+
+        onClicked: {
+            if(radioButton.canToggle || !radioButton.checked)
+                radioButton.checked = !radioButton.checked
+        }
 
         circular: true
         centered: true
+    }
+
+    MouseArea {
+        anchors {
+            left: inkArea.right
+            top: parent.top
+            right: parent.right
+            bottom: parent.bottom
+        }
+        onClicked: {
+            if(radioButton.canToggle || !radioButton.checked)
+                radioButton.checked = !radioButton.checked
+        }
     }
 }


### PR DESCRIPTION
Fixes:
- The RadioButton was not allowing selection if you clicked on it's text area

Adds:
- New canToggle property to allow a developer to specify that a radio button can go back to a unchecked state manually

- Updates demo to be a little more real world 