### PR TITLE
[Dialog] Handling back button of Android devices

### DIFF
--- a/modules/Material/Dialog.qml
+++ b/modules/Material/Dialog.qml
@@ -73,7 +73,12 @@ PopupBase {
         NumberAnimation { duration: 200 }
     }
 
-    Keys.onEscapePressed: dialog.close()
+    Keys.onPressed: {
+        if (event.key === Qt.Key_Escape || event.key === Qt.Key_Back) {
+            dialog.close()
+            event.accepted = true
+        }
+    }
 
     function show() {
         open()


### PR DESCRIPTION
Pressing the back button on an Android device while a dialog is open
does no longer quit the whole app, but rather dismisses the dialog.
I tested this on my Android phone.