### PR TITLE
Support preventing a popup from being dismissed

### DIFF
--- a/modules/Material/Device.qml
+++ b/modules/Material/Device.qml
@@ -78,5 +78,5 @@ Object {
         }
     }
 
-    readonly property bool isMobile: type == phone || type == tablet
+    readonly property bool isMobile: type == phone || type == phablet || type == tablet
 }

--- a/modules/Material/OverlayLayer.qml
+++ b/modules/Material/OverlayLayer.qml
@@ -48,7 +48,7 @@ Rectangle {
         anchors.fill: parent
         enabled: overlayLayer.currentOverlay != null && overlayLayer.currentOverlay.globalMouseAreaEnabled
         hoverEnabled: enabled
-        onClicked: overlayLayer.currentOverlay.close()
+        onClicked: if (overlayLayer.currentOverlay.dismissOnTap) overlayLayer.currentOverlay.close()
         onWheel: wheel.accepted = true
     }
 }

--- a/modules/Material/PopupBase.qml
+++ b/modules/Material/PopupBase.qml
@@ -25,6 +25,7 @@ FocusScope {
     property color overlayColor: "transparent"
     property string overlayLayer: "overlayLayer"
     property bool globalMouseAreaEnabled: true
+    property bool dismissOnTap: true
     property bool showing: false
 
     signal opened


### PR DESCRIPTION
Sometimes it is necessary to "lock" the screen while the user waits a long process, and this is not possible with the current implementation of PopupBase and OverlayLayer.