### PR TITLE
Popping Pages from PageStack on escape key and Android back button

### DIFF
--- a/modules/Material/Page.qml
+++ b/modules/Material/Page.qml
@@ -164,20 +164,29 @@ FocusScope {
      */
     function pop() {
         if (Controls.Stack.view.currentItem == page)
-            Controls.Stack.view.pop();
+            return Controls.Stack.view.pop();
     }
 
     /*!
        Push the specified component onto the page stack.
      */
     function push(component, properties) {
-        Controls.Stack.view.push({item: component, properties: properties});
+        return Controls.Stack.view.push({item: component, properties: properties});
     }
 
     onRightSidebarChanged: {
         if (rightSidebar)
             rightSidebar.mode = "right"
     }
+
+    Keys.onPressed: {
+        if (event.key === Qt.Key_Escape || event.key === Qt.Key_Back) {
+            if (pop()) {
+                event.accepted = true;
+            }
+        }
+    }
+
 
     ActionBar {
         id: __actionBar


### PR DESCRIPTION
If there is more than one Page on the PageStack, one page is popped from the PageStack when the user presses the escape key or the back button on Android devices.
I was not sure if pages should be popped when the user presses the escape key, so I just included it. If this isn't desired behaviour, I can easily change it so that only the Android back button pops pages.