### PR TITLE
[Floating Action Button] Add support for proper FAB sizing per google specs.

### DIFF
--- a/modules/Material/ActionButton.qml
+++ b/modules/Material/ActionButton.qml
@@ -59,6 +59,13 @@ Controls.Button {
      */
     property string iconName
 
+    /*!
+       Floating action buttons come in two sizes:
+       Default size: For most use cases
+       Mini size: Only used to create visual continuity with other screen elements
+     */
+    property bool isMiniSize: false
+
     style: ControlStyles.ButtonStyle {
         background: Item {
             RectangularGlow {
@@ -103,9 +110,8 @@ Controls.Button {
             }
         }
         label: Item {
-            implicitHeight: units.dp(40)
-            implicitWidth: units.dp(40)
-
+            implicitHeight: isMiniSize ? units.dp(40) : units.dp(56)
+            implicitWidth: implicitHeight
             Icon {
                 id: icon
 


### PR DESCRIPTION
Updated FAB sizing to new google specs:

http://www.google.com/design/spec/components/buttons-floating-action-button.html#buttons-floating-action-button-floating-action-button

"Floating action buttons come in two sizes:

Default size: For most use cases
Mini size: Only used to create visual continuity with other screen elements"

Default : 

![image](https://cloud.githubusercontent.com/assets/1914540/7394641/d446ec70-ee62-11e4-95ba-809e30c4facf.png)


Mini :

![image](https://cloud.githubusercontent.com/assets/1914540/7394645/dde04240-ee62-11e4-9ce1-b2aa11a469a8.png)
 