### PR TITLE
[Dialog] Active focus is passed off when Dialog closes

### DIFF
--- a/modules/Material/Dialog.qml
+++ b/modules/Material/Dialog.qml
@@ -90,7 +90,7 @@ PopupBase {
     }
 
     Keys.onPressed: {
-        if (event.key === Qt.Key_Escape || event.key === Qt.Key_Back) {
+        if ((event.key === Qt.Key_Escape || event.key === Qt.Key_Back) && dialog.showing) {
             dialog.close()
             event.accepted = true
         }

--- a/modules/Material/Dialog.qml
+++ b/modules/Material/Dialog.qml
@@ -91,7 +91,9 @@ PopupBase {
 
     Keys.onPressed: {
         if ((event.key === Qt.Key_Escape || event.key === Qt.Key_Back) && dialog.showing) {
-            dialog.close()
+            if (dialog.dismissOnTap) {
+                dialog.close()
+            }
             event.accepted = true
         }
     }

--- a/modules/Material/Dialog.qml
+++ b/modules/Material/Dialog.qml
@@ -90,7 +90,19 @@ PopupBase {
     }
 
     Keys.onPressed: {
-        if ((event.key === Qt.Key_Escape || event.key === Qt.Key_Back) && dialog.showing) {
+        if (event.key === Qt.Key_Escape) {
+            closeKeyPressed(event)
+        }
+    }
+
+    Keys.onReleased: {
+        if (event.key === Qt.Key_Back) {
+            closeKeyPressed(event)
+        }
+    }
+
+    function closeKeyPressed(event) {
+        if (dialog.showing) {
             if (dialog.dismissOnTap) {
                 dialog.close()
             }

--- a/modules/Material/Page.qml
+++ b/modules/Material/Page.qml
@@ -181,7 +181,7 @@ FocusScope {
             rightSidebar.mode = "right"
     }
 
-    Keys.onPressed: {
+    Keys.onReleased: {
         if (event.key === Qt.Key_Back) {
             // When the Android back button is tapped
             if (__actionBar.overflowMenuShowing) {

--- a/modules/Material/PopupBase.qml
+++ b/modules/Material/PopupBase.qml
@@ -27,7 +27,6 @@ FocusScope {
     property bool globalMouseAreaEnabled: true
     property bool dismissOnTap: true
     property bool showing: false
-    property Item nextFocusItem
 
     signal opened
 
@@ -51,8 +50,5 @@ FocusScope {
     function close() {
         showing = false
         parent.currentOverlay = null
-        if (nextFocusItem) {
-            nextFocusItem.forceActiveFocus()
-        }
     }
 }

--- a/modules/Material/PopupBase.qml
+++ b/modules/Material/PopupBase.qml
@@ -27,6 +27,7 @@ FocusScope {
     property bool globalMouseAreaEnabled: true
     property bool dismissOnTap: true
     property bool showing: false
+    property Item nextFocusItem
 
     signal opened
 
@@ -50,5 +51,8 @@ FocusScope {
     function close() {
         showing = false
         parent.currentOverlay = null
+        if (nextFocusItem) {
+            nextFocusItem.forceActiveFocus()
+        }
     }
 }

--- a/modules/Material/PopupBase.qml
+++ b/modules/Material/PopupBase.qml
@@ -16,6 +16,7 @@
 * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 import QtQuick 2.0
+import QtQuick.Window 2.2
 import Material 0.1
 import Material.Extras 0.1
 
@@ -27,6 +28,7 @@ FocusScope {
     property bool globalMouseAreaEnabled: true
     property bool dismissOnTap: true
     property bool showing: false
+    property Item __lastFocusedItem
 
     signal opened
 
@@ -39,6 +41,7 @@ FocusScope {
     }
 
     function open() {
+        __lastFocusedItem = Window.activeFocusItem
         parent = Utils.findRootChild(popup, overlayLayer)
         showing = true
         forceActiveFocus()
@@ -50,5 +53,8 @@ FocusScope {
     function close() {
         showing = false
         parent.currentOverlay = null
+        if (__lastFocusedItem !== null) {
+            __lastFocusedItem.forceActiveFocus()
+        }
     }
 }


### PR DESCRIPTION
Up to now, after a Dialog was closed, the key capturing on the Page was
blocked, because the Dialog element didn't pass on the active focus to
another element.
Now the Dialog has a new property nextFocusItem, this Item will be
focused when the Dialog is dismissed.

I experienced this problem, when the Android back button didn't work anymore (it didn't quit the app) after a Dialog was opened and closed.
I am not 100% satisfied with this solution, because you always have to set the Item that will be focused after the Dialog explicitly, e.g.

```qml
Page {
    id: page

    Dialog {
        nextFocusItem: page
    }
}
```

So I'm open to your suggestions about this problem.