### PR TITLE
[Page] Overflow menu of ActionBar controlled by Android hardware buttons

### DIFF
--- a/modules/Material/ActionBar.qml
+++ b/modules/Material/ActionBar.qml
@@ -132,6 +132,17 @@ Item {
      */
     property Item toolbar
 
+    property alias overflowMenuShowing: overflowMenu.showing
+    property bool overflowMenuAvailable: __internal.visibleActions.length > maxActionCount
+
+    function openOverflowMenu() {
+        overflowMenu.open(overflowButton, units.dp(4), units.dp(-4));
+    }
+
+    function closeOverflowMenu() {
+        overflowMenu.close();
+    }
+
     QtObject {
         id: __internal
 
@@ -230,10 +241,10 @@ Item {
             size: units.dp(27)
             color: Theme.lightDark(actionBar.backgroundColor, Theme.light.iconColor,
                                                               Theme.dark.iconColor)
-            visible: __internal.visibleActions.length > maxActionCount
+            visible: actionBar.overflowMenuAvailable
             anchors.verticalCenter: parent.verticalCenter
 
-            onClicked: overflowMenu.open(overflowButton, units.dp(4), units.dp(-4))
+            onClicked: openOverflowMenu()
         }
     }
 

--- a/modules/Material/Page.qml
+++ b/modules/Material/Page.qml
@@ -182,9 +182,26 @@ FocusScope {
     }
 
     Keys.onPressed: {
-        // Pop the page from the page stack when the Android back button is tapped
         if (event.key === Qt.Key_Back) {
-            if (pop()) {
+            // When the Android back button is tapped
+            if (__actionBar.overflowMenuShowing) {
+                // Close the action bar overflow menu if it's open
+                __actionBar.closeOverflowMenu();
+                event.accepted = true;
+            } else {
+                // or pop the page from the page stack
+                if (pop()) {
+                    event.accepted = true;
+                }
+            }
+        } else if (event.key === Qt.Key_Menu) {
+            // Display or hide the action bar overflow menu when the Android menu button is tapped
+            if (__actionBar.overflowMenuAvailable) {
+                if (__actionBar.overflowMenuShowing) {
+                    __actionBar.closeOverflowMenu();
+                } else {
+                    __actionBar.openOverflowMenu();
+                }
                 event.accepted = true;
             }
         }


### PR DESCRIPTION
When the user presses the menu hardware button on his Android device,
the overflow menu of the current page pops up, if there is one.
Pressing the back button or pressing the menu button again closes the
overflow menu.