### PR TITLE
[BottomActionSheet] Fix wrong ID

### DIFF
--- a/modules/Material/BottomActionSheet.qml
+++ b/modules/Material/BottomActionSheet.qml
@@ -92,7 +92,7 @@ BottomSheet {
                                 enabled: modelData.enabled
                                 
                                 onClicked: {
-                                    actionSheet.close()
+                                    bottomSheet.close()
                                     modelData.triggered(listItem)
                                 }
                             }


### PR DESCRIPTION
It should be bottomSheet instead of actionSheet, which only works in the demo because in BottomSheetDemo.qml the same id is used