### PR TITLE
Fix a reference bug in ProgressCircle

### DIFF
--- a/modules/Material/ProgressCircle.qml
+++ b/modules/Material/ProgressCircle.qml
@@ -81,9 +81,9 @@ Controls.ProgressBar {
 
                 Connections {
                     target: control
-                    onColorChanged: requestPaint()
-                    onValueChanged: requestPaint()
-                    onDashThicknessChanged: requestPaint()
+                    onColorChanged: canvas.requestPaint()
+                    onValueChanged: canvas.requestPaint()
+                    onDashThicknessChanged: canvas.requestPaint()
                     onIndeterminateChanged:
                     {
                         if(control.indeterminate)
@@ -93,7 +93,7 @@ Controls.ProgressBar {
                             internal.rotate = 0
                         }
 
-                        requestPaint();
+                        canvas.requestPaint();
                     }
                 }
 


### PR DESCRIPTION
ProgressCircle was warning about a missing reference for requestPaint in the Connexions item.
It was working, but the shell from which I launched the scene was yelling to much *ReferenceError* to make it readable.