### PR TITLE
Disable NavigationDrawer's action when drawer is disabled

### DIFF
--- a/modules/Material/NavigationDrawer.qml
+++ b/modules/Material/NavigationDrawer.qml
@@ -67,6 +67,7 @@ PopupBase {
         iconName: "navigation/menu"
         name: "Navigation Drawer"
         onTriggered: navDrawer.toggle()
+        enabled: navDrawer.enabled
     }
 
     View {

--- a/modules/Material/ProgressCircle.qml
+++ b/modules/Material/ProgressCircle.qml
@@ -81,9 +81,9 @@ Controls.ProgressBar {
 
                 Connections {
                     target: control
-                    onColorChanged: requestPaint()
-                    onValueChanged: requestPaint()
-                    onDashThicknessChanged: requestPaint()
+                    onColorChanged: canvas.requestPaint()
+                    onValueChanged: canvas.requestPaint()
+                    onDashThicknessChanged: canvas.requestPaint()
                     onIndeterminateChanged:
                     {
                         if(control.indeterminate)
@@ -93,7 +93,7 @@ Controls.ProgressBar {
                             internal.rotate = 0
                         }
 
-                        requestPaint();
+                        canvas.requestPaint();
                     }
                 }
 


### PR DESCRIPTION
This pr fixes the issue #220 by binding the enabled property of the NavigationDrawer's action to the NavigationDrawer's enabled property. That way if the drawer is disabled, its action is disabled as well.