### PR TITLE
[Slider] Add customization options to the slider's floating knob

### DIFF
--- a/demo/SliderDemo.qml
+++ b/demo/SliderDemo.qml
@@ -86,6 +86,25 @@ ColumnLayout {
                 }
 
                 Label {
+                    text: "Customized Numeric Value Label"
+                    wrapMode: Text.WordWrap
+                    Layout.alignment:  Qt.AlignBottom
+                    color: index == 0 ? Theme.light.textColor : Theme.dark.textColor
+                }
+
+                Slider {
+                    Layout.alignment: Qt.AlignCenter
+                    numericValueLabel: true
+                    stepSize: 1
+                    minimumValue: 0
+                    maximumValue: 100
+                    alwaysShowValueLabel: true
+                    knobLabel: value + "%"
+                    knobDiameter: Units.dp(42)
+                    darkBackground: index == 1
+                }
+
+                Label {
                     text: "Disabled"
                     color: index == 0 ? Theme.light.textColor : Theme.dark.textColor
                 }

--- a/modules/Material/Slider.qml
+++ b/modules/Material/Slider.qml
@@ -25,21 +25,36 @@ import QtQuick.Controls.Styles.Material 0.1 as MaterialStyle
    \qmltype Slider
    \inqmlmodule Material 0.1
 
-   \brief Sliders let users select a value from a continuous or discrete range of 
+   \brief Sliders let users select a value from a continuous or discrete range of
    values by moving the slider thumb.
  */
 Controls.Slider {
     id: slider
 
     /*!
-       Set to \c true to enable a float numeric value label above the slider knob
+       Set to \c true to enable a floating numeric value label above the slider knob
      */
     property bool numericValueLabel: false
+
+    /*!
+       Set to \c true to always show the numeric value label, even when not pressed
+     */
+    property bool alwaysShowValueLabel: false
 
     /*!
        Set to \c true if the switch is on a dark background
      */
     property bool darkBackground
+
+    /*!
+       The label to display within the value label knob, by default the sliders current value
+     */
+    property string knobLabel: slider.value
+
+    /*!
+       The diameter of the value label knob
+     */
+    property int knobDiameter: Units.dp(32)
 
     property color color: darkBackground ? Theme.dark.accentColor
                                          : Theme.light.accentColor

--- a/modules/QtQuick/Controls/Styles/Material/SliderStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/SliderStyle.qml
@@ -32,19 +32,39 @@ SliderStyle {
     property bool numericValueLabel: control.hasOwnProperty("numericValueLabel")
             ? control.numericValueLabel : false
 
+    property bool alwaysShowValueLabel: control.hasOwnProperty("alwaysShowValueLabel")
+            ? control.alwaysShowValueLabel : false
+
+    property string knobLabel: control.hasOwnProperty("knobLabel")
+            ? control.knobLabel : control.value
+
+    property int knobDiameter: control.hasOwnProperty("knobDiameter")
+            ? control.knobDiameter : Units.dp(32)
+
     property Component knob : Item {
-        implicitHeight: control.pressed || control.focus ? Units.dp(32) : 0
-        implicitWidth: control.pressed || control.focus ? Units.dp(32) : 0
+        implicitHeight: control.pressed || control.focus || control.alwaysShowValueLabel ? knobDiameter : 0
+        implicitWidth: control.pressed || control.focus || control.alwaysShowValueLabel ? knobDiameter : 0
 
         Label {
-            anchors.fill: parent
+            anchors {
+                fill: parent
+                topMargin: Units.dp(4)
+                bottomMargin: Units.dp(2)
+                leftMargin: Units.dp(4)
+                rightMargin: Units.dp(4)
+            }
+
             horizontalAlignment: Qt.AlignHCenter
             verticalAlignment: Qt.AlignVCenter
-            text: control.value
+            text: knobLabel
+            fontSizeMode: Text.Fit
+            font.pixelSize: knobDiameter - Units.dp(19)
+            minimumPixelSize: Units.dp(6)
+            wrapMode: Text.WordWrap
             color: Theme.lightDark(styleColor,
-                                            Theme.light.textColor,
-                                            Theme.dark.textColor)
-            opacity: control.pressed || control.focus ? 1 : 0
+                                    Theme.light.textColor,
+                                    Theme.dark.textColor)
+            opacity: control.pressed || control.focus || control.alwaysShowValueLabel ? 1 : 0
             z: 1
 
             property color styleColor: control.hasOwnProperty("color")


### PR DESCRIPTION
This allows the knob's floating label to have its value customized.
The label will adjust its size and positioning to best fit the knobs size, which is also now configurable.

Example:

![customizedslider](https://cloud.githubusercontent.com/assets/1914540/8595135/ace45d12-2615-11e5-83ef-c68a860503df.gif)
