### PR TITLE
Remove qml-extras build from travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ install:
   - sudo apt-get -y install qt54tools
 
 before_script:
-  - source /opt/qt54/bin/qt54-env.sh
-  - git clone git://github.com/papyros/qml-extras.git
-  - pushd qml-extras
-  - qmake
-  - sudo make install
-  - popd
   - git clone git://github.com/papyros/docmaker.git
   - sudo pip install -r docmaker/requirements.txt
   - npm install -g jslint


### PR DESCRIPTION
qml-extras has now been included into the qml-material project,
so it is no longer a required dependency for the CI.