### PR TITLE
Fixes the lint warnings in Material.Extras

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - popd
   - git clone git://github.com/papyros/docmaker.git
   - sudo pip install -r docmaker/requirements.txt
-  - npm install -g jslint
+  - npm install -g jshint
   - export PATH=$PATH:$(pwd)/docmaker
 
 script:

--- a/lint.sh
+++ b/lint.sh
@@ -19,7 +19,7 @@ for file in $pyfiles; do
 	pep8 $file || fail=1
 done
 
-echo ">>> Checking Javascript files using jslint"
+echo ">>> Checking Javascript files using jshint"
 
 srcdir=$(pwd)
 
@@ -27,8 +27,8 @@ cd $tempdir
 
 for file in $jsfiles; do
 	mkdir -p $(dirname $file)
-	sed "s/\.pragma .*//g" < $srcdir/$file > $file
-	jslint $file || fail=1
+	sed "s/\.pragma .*//g; s/\.import .*//g" < $srcdir/$file > $file
+	jshint $file || fail=1
 done
 
 if [[ $fail == 1 ]]; then

--- a/modules/Material/Extras/js/dateutils.js
+++ b/modules/Material/Extras/js/dateutils.js
@@ -19,28 +19,27 @@
 
 .pragma library
 
-var today = new Date()
-today.setHours(0)
-today.setMinutes(0)
-today.setSeconds(0)
-today.setMilliseconds(0)
+var today = new Date();
+today.setHours(0);
+today.setMinutes(0);
+today.setSeconds(0);
+today.setMilliseconds(0);
 
 function formattedDate(date) {
     if (isToday(date)) {
-        return "Today (%1)".arg(dayOfWeek(date))
+        return "Today (%1)".arg(dayOfWeek(date));
     } else if (isTomorrow(date)) {
-        return "Tomorrow (%1)".arg(dayOfWeek(date))
+        return "Tomorrow (%1)".arg(dayOfWeek(date));
     } else {
-        return date.toLocaleDateString(Qt.locale())
+        return date.toLocaleDateString(Qt.locale());
     }
 }
 
 function dayOfWeek(date) {
-    return Qt.formatDate(date, "dddd")
+    return Qt.formatDate(date, "dddd");
 }
 
 function setDayOfWeek(date, day) {
-
     var currentDay = date.getDay();
     var distance = day - currentDay;
     date.setDate(date.getDate() + distance);
@@ -48,87 +47,88 @@ function setDayOfWeek(date, day) {
 
 function dayOfWeekIndex(date) {
     if (!date)
-        date = new Date()
+        date = new Date();
 
-    var list = []
+    var list = [];
     for (var i = 0; i < 7; i++) {
-        list.push(Qt.locale().dayName(i))
+        list.push(Qt.locale().dayName(i));
     }
-    var day = Qt.formatDate(date, "dddd")
-    return list.indexOf(day)
+    var day = Qt.formatDate(date, "dddd");
+    return list.indexOf(day);
 }
 
 function isToday(date) {
-    var today = new Date()
+    var today = new Date();
 
-    return datesEqual(date, today)
+    return datesEqual(date, today);
 }
 
 function isTomorrow(date) {
-    var today = new Date()
-    today.setDate(today.getDate() + 1)
+    var today = new Date();
+    today.setDate(today.getDate() + 1);
 
-    return datesEqual(date, today)
+    return datesEqual(date, today);
 }
 
 function isThisWeek(date) {
-    var endOfWeek = new Date()
-    setDayOfWeek(endOfWeek, 6)
+    var endOfWeek = new Date();
+    setDayOfWeek(endOfWeek, 6);
 
-    return dateIsBeforeOrSame(date, endOfWeek)
+    return dateIsBeforeOrSame(date, endOfWeek);
 }
 
 function datesEqual(date1, date2) {
     return date1.getFullYear() === date2.getFullYear() &&
             date1.getMonth() === date2.getMonth() &&
-            date1.getDate() === date2.getDate()
+            date1.getDate() === date2.getDate();
 }
 
 function dateIsBefore(date1, date2) {
+    /* jshint laxbreak: true */
     var ans = date1.getFullYear() < date2.getFullYear() ||
             (date1.getFullYear() === date2.getFullYear() && date1.getMonth() < date2.getMonth()) ||
-            (date1.getFullYear() === date2.getFullYear() && date1.getMonth() === date2.getMonth()
-                    && date1.getDate() < date2.getDate())
-    return ans
+            (date1.getFullYear() === date2.getFullYear() && date1.getMonth() === date2.getMonth() &&
+             date1.getDate() < date2.getDate());
+    return ans;
 }
 
 function dateIsBeforeOrSame(date1, date2) {
     var ans = date1.getFullYear() < date2.getFullYear() ||
             (date1.getFullYear() === date2.getFullYear() && date1.getMonth() < date2.getMonth()) ||
-            (date1.getFullYear() === date2.getFullYear() && date1.getMonth() === date2.getMonth()
-                    && date1.getDate() <= date2.getDate())
-    return ans
+            (date1.getFullYear() === date2.getFullYear() && date1.getMonth() === date2.getMonth() &&
+             date1.getDate() <= date2.getDate());
+    return ans;
 }
 
 function dateIsThisWeek(date) {
-    var end = new Date()
-    end.setDate(end.getDate() + 7)
-    return dateIsBefore(date, end)
+    var end = new Date();
+    end.setDate(end.getDate() + 7);
+    return dateIsBefore(date, end);
 }
 
 function friendlyTime(time, standalone) {
-    var now = new Date()
-    time = new Date(time)
+    var now = new Date();
+    time = new Date(time);
     var seconds = (now - time)/1000;
     //print("Difference:", now, time, now - time)
     var minutes = Math.round(seconds/60);
     if (minutes < 1)
-        return standalone ? ("Now") : "now"
+        return standalone ? ("Now") : "now";
     else if (minutes == 1)
-        return ("1 minute ago")
+        return ("1 minute ago");
     else if (minutes < 60)
-        return ("%1 minutes ago").arg(minutes)
+        return ("%1 minutes ago").arg(minutes);
     var hours = Math.round(minutes/60);
     if (hours == 1)
-        return ("1 hour ago")
+        return ("1 hour ago");
     else if (hours < 24)
-        return ("%1 hours ago").arg(hours)
-    var days = Math.round(hours/24)
+        return ("%1 hours ago").arg(hours);
+    var days = Math.round(hours/24);
     if (days == 1)
-        return ("1 day ago")
+        return ("1 day ago");
     else if (days <= 10)
-        return ("%1 days ago").arg(days)
-    return standalone ? Qt.formatDate(time) : ("on %1").arg(Qt.formatDate(time))
+        return ("%1 days ago").arg(days);
+    return standalone ? Qt.formatDate(time) : ("on %1").arg(Qt.formatDate(time));
 }
 
 function pad(n, width, z) {
@@ -138,47 +138,47 @@ function pad(n, width, z) {
 }
 
 function shortDuration(duration, type) {
-    var hours = Math.floor(duration/(1000 * 60 * 60))
-    var minutes = Math.floor(duration/(1000 * 60) - 60 * hours)
-    var seconds = Math.floor(duration/1000 - 60 * minutes - 60 * 60 * hours)
+    var hours = Math.floor(duration/(1000 * 60 * 60));
+    var minutes = Math.floor(duration/(1000 * 60) - 60 * hours);
+    var seconds = Math.floor(duration/1000 - 60 * minutes - 60 * 60 * hours);
 
     if (type === undefined)
-        type = '?'
+        type = '?';
 
-    var str = ''
+    var str = '';
     if (type === 's' || type === '?')
-        str = "%1".arg(pad(seconds, 2))
+        str = "%1".arg(pad(seconds, 2));
     if (type === 's' || type === 'm' || (type === '?' && (minutes >= 1 || hours >= 1))) {
         if (str.length > 0)
-            str = "%1:%2".arg(pad(minutes, 2)).arg(str)
+            str = "%1:%2".arg(pad(minutes, 2)).arg(str);
         else
-            str = "%1".arg(pad(minutes, 2))
+            str = "%1".arg(pad(minutes, 2));
     }
     if (type === 's' || type === 'm' || type === 'h' || (type === '?' && hours >= 1)) {
         if (str.length > 0)
-            str = "%1:%2".arg(hours).arg(str)
+            str = "%1:%2".arg(hours).arg(str);
         else
-            str = "%1".arg(hours)
+            str = "%1".arg(hours);
     }
-    return str.trim()
+    return str.trim();
 }
 
 function friendlyDuration(duration, type) {
-    var hours = Math.floor(duration/(1000 * 60 * 60))
-    var minutes = Math.floor(duration/(1000 * 60) - 60 * hours)
-    var seconds = Math.floor(duration/1000 - 60 * minutes - 60 * 60 * hours)
+    var hours = Math.floor(duration/(1000 * 60 * 60));
+    var minutes = Math.floor(duration/(1000 * 60) - 60 * hours);
+    var seconds = Math.floor(duration/1000 - 60 * minutes - 60 * 60 * hours);
 
     if (type === undefined)
-        type = '?'
+        type = '?';
 
-    var str = ''
+    var str = '';
     if (type === 's' || type === '?')
-        str = "%1s".arg(seconds)
+        str = "%1s".arg(seconds);
     if (type === 's' || type === 'm' || (type === '?' && (minutes >= 1 || hours >= 1)))
-        str = "%1m %2".arg(minutes).arg(str)
+        str = "%1m %2".arg(minutes).arg(str);
     if (type === 's' || type === 'm' || type === 'h' || (type === '?' && hours >= 1))
-        str = "%1h %2".arg(hours).arg(str)
-    return str.trim()
+        str = "%1h %2".arg(hours).arg(str);
+    return str.trim();
 }
 
 function parseDuration(str) {
@@ -188,18 +188,18 @@ function parseDuration(str) {
     var seconds = str.match(/(\d+)\s*s/);
     var time = 0;
     if (days)
-        time += parseInt(days[1]) * 86400
+        time += parseInt(days[1]) * 86400;
     if (hours)
-        time += parseInt(hours[1]) * 3600
+        time += parseInt(hours[1]) * 3600;
     if (minutes)
-        time += parseInt(minutes[1]) * 60
+        time += parseInt(minutes[1]) * 60;
     if (seconds)
-        time += parseInt(seconds[1])
+        time += parseInt(seconds[1]);
     return time * 1000;
 }
 
 function daysUntilDate(date) {
-    return Math.floor((new Date(date) - new Date())/(1000*60*60*24))
+    return Math.floor((new Date(date) - new Date())/(1000*60*60*24));
 }
 
 function toUTC(date) {
@@ -207,10 +207,10 @@ function toUTC(date) {
 }
 
 function timeFromDate(date) {
-    print(date.getSeconds(),date.getMinutes() * 60,date.getHours() * 3600)
-    return 1000 * (date.getSeconds() + date.getMinutes() * 60 + date.getHours() * 3600)
+    print(date.getSeconds(),date.getMinutes() * 60,date.getHours() * 3600);
+    return 1000 * (date.getSeconds() + date.getMinutes() * 60 + date.getHours() * 3600);
 }
 
 function isValid(date) {
-    return date.toString() != "Invalid Date"
+    return date.toString() != "Invalid Date";
 }

--- a/modules/Material/Extras/js/httplib.js
+++ b/modules/Material/Extras/js/httplib.js
@@ -21,15 +21,15 @@
 .import "promises.js" as Promises
 
 function post(path, args, timeout) {
-    return request(path, "POST", args, timeout)
+    return request(path, "POST", args, timeout);
 }
 
 function patch(path, args, timeout) {
-    return request(path, "POST", args, timeout)
+    return request(path, "POST", args, timeout);
 }
 
 function put(path, args, timeout) {
-    return request(path, "PUT", args, timeout)
+    return request(path, "PUT", args, timeout);
 }
 
 //function delete(path, options, args) {
@@ -37,35 +37,34 @@ function put(path, args, timeout) {
 //}
 
 function get(path, args, timeout) {
-    return request(path, "GET", args, timeout)
+    return request(path, "GET", args, timeout);
 }
 
 function request(path, call, args, timeout) {
-    var address = path
+    var address = path;
 
-    if (!args) args = {}
+    if (!args) args = {};
 
-    var options = args.options ? args.options : []
-    var headers = args.headers ? args.headers : {}
-    var body = args.body ? args.body : undefined
+    var options = args.options ? args.options : [];
+    var headers = args.headers ? args.headers : {};
+    var body = args.body ? args.body : undefined;
 
     if (options.length > 0)
-        address += (address.indexOf('?') == -1 ? "?" : "&") + options.join("&").replace(/ /g, "%20")
+        address += (address.indexOf('?') == -1 ? "?" : "&") + options.join("&").replace(/ /g, "%20");
 
-    print(call, address, body)
-    print("Headers", JSON.stringify(headers))
+    print(call, address, body);
+    print("Headers", JSON.stringify(headers));
 
-    var promise = new Promises.Promise()
-
+    var promise = new Promises.Promise();
     var doc = new XMLHttpRequest();
+    var timer;
 
-    var timer
     if(timeout !== undefined) {
-        console.log("Creating timer.")
-        timer = Qt.createQmlObject("import QtQuick 2.3; Timer {interval: " + timeout + "; repeat: false; running: true;}", Qt.application, "XHRTimer")
-        timer.triggered.connect(function(){
-            doc.hasTimeout = true
-            doc.abort()
+        console.log("Creating timer.");
+        timer = Qt.createQmlObject("import QtQuick 2.3; Timer {interval: " + timeout + "; repeat: false; running: true;}", Qt.application, "XHRTimer");
+        timer.triggered.connect(function() {
+            doc.hasTimeout = true;
+            doc.abort();
         });
     }
 
@@ -76,67 +75,69 @@ function request(path, call, args, timeout) {
             //print(doc.responseText)
 
             if (timer) {
-                console.log("Destroing timer.")
-                timer.destroy()
-                timer = undefined
+                console.log("Destroing timer.");
+                timer.destroy();
+                timer = undefined;
             }
 
-            var responseArray = doc.getAllResponseHeaders().split('\n')
-            var responseHeaders = {}
+            var responseArray = doc.getAllResponseHeaders().split('\n');
+            var responseHeaders = {};
+
             for (var i = 0; i < responseArray.length; i++) {
-                var header = responseArray[i]
-                var items = split(header, ':', 1)
-                responseHeaders[items[0]] = items[1]
+                var header = responseArray[i];
+                var items = split(header, ':', 1);
+                responseHeaders[items[0]] = items[1];
             }
 
             //print("Status:",doc.status, "for call", call, address, headers['If-None-Match'], responseHeaders['etag'])
 
-            promise.info.headers = responseHeaders
-            promise.info.status = doc.status
+            promise.info.headers = responseHeaders;
+            promise.info.status = doc.status;
 
             if (doc.status == 200 || doc.status == 201 || doc.status == 202 || doc.status === 304) {
-                print("Calling back with no error...")
-                promise.resolve(doc.responseText)
+                print("Calling back with no error...");
+                promise.resolve(doc.responseText);
             } else {
-                print("Calling back with error...")
+                print("Calling back with error...");
                 var error = doc.responseText;
                 if (doc.hasTimeout) {
-                    error = "Connection timeout."
+                    error = "Connection timeout.";
                 }
-                promise.reject(error)
+                promise.reject(error);
             }
         }
-    }
+    };
 
     doc.open(call, address, true);
     for (var key in headers) {
         //print(key + ": " + headers[key])
-        doc.setRequestHeader(key, headers[key])
+        doc.setRequestHeader(key, headers[key]);
     }
+
     if (body)
-        doc.send(body)
+        doc.send(body);
     else
         doc.send();
 
-    return promise
+    return promise;
 }
 
 function split(string, sep, limit) {
-    var array = []
+    var array = [];
     for (var i = 0; i < limit; i++) {
-        var index = string.indexOf(sep)
+        var index = string.indexOf(sep);
         if (index === -1) {
-            array.push(string)
-            string = undefined
+            array.push(string);
+            string = undefined;
             break;
         } else {
-            array.push(string.substring(0, index))
-            string = string.substring(index+1)
+            array.push(string.substring(0, index));
+            string = string.substring(index+1);
         }
     }
 
     if (string !== undefined)
-        array.push(string.trim())
+        array.push(string.trim());
 
-    return array
+    return array;
 }

--- a/modules/Material/Extras/js/listutils.js
+++ b/modules/Material/Extras/js/listutils.js
@@ -19,148 +19,150 @@
 
 .pragma library
 
-function filter(tasks, filter, name) {
+function filter(tasks, filter_func, name) {
     //print("Running filter:", name)
-    var list = []
+    var list = [];
 
-    if (tasks.hasOwnProperty('busy') && tasks.busy) return list
+    if (tasks.hasOwnProperty('busy') && tasks.busy)
+        return list;
 
     for (var i = 0; i < length(tasks); i++) {
-        var task = getItem(tasks, i)
+        var task = getItem(tasks, i);
         //print("Filtering:", task.name)
-        if (filter(task))
-            list.push(task)
+        if (filter_func(task))
+            list.push(task);
     }
 
     //print("Filtered list:", list)
 
-    return list
+    return list;
 }
 
 function filteredCount(model, func, name) {
-    return filter(model, func, name).length
+    return filter(model, func, name).length;
 }
 
 function iter(list, func) {
-    var value = 0
+    var value = 0;
 
     for (var i = 0; i < length(list); i++) {
-        var item = getItem(list, i)
-        var ans = func(item)
-        value += ans
+        var item = getItem(list, i);
+        var ans = func(item);
+        value += ans;
     }
 
-    return value
+    return value;
 }
 
 function filteredSum(list, prop, func, name) {
-    var value = 0
+    var value = 0;
 
     for (var i = 0; i < length(list); i++) {
-        var item = getItem(list, i)
-        value += filteredCount(item[prop], func, name)
+        var item = getItem(list, i);
+        value += filteredCount(item[prop], func, name);
     }
 
-    return value
+    return value;
 }
 
 function sum(list, prop) {
-    var value = 0
+    var value = 0;
 
     for (var i = 0; i < length(list); i++) {
-        var item = getItem(list, i)
-        value += item[prop]
+        var item = getItem(list, i);
+        value += item[prop];
     }
 
-    return value
+    return value;
 }
 
 function subList(list, prop) {
-    var value = []
+    var value = [];
 
     //print("Concat:", prop, length(list))
 
     for (var i = 0; i < length(list); i++) {
-        var item = getItem(list, i)
-        value.push(item[prop])
+        var item = getItem(list, i);
+        value.push(item[prop]);
     }
 
     //print("Concat:", prop, value, length(value))
-    return value
+    return value;
 }
 
 function toList(model) {
-    var list = []
+    var list = [];
 
     for (var i = 0; i < model.count; i++) {
-        list.push(getItem(model, i))
+        list.push(getItem(model, i));
     }
 
-    return list
+    return list;
 }
 
 function sort(list, prop) {
     if (list.hasOwnProperty("count"))
-        list = toList(list)
+        list = toList(list);
     //print("Sorting by", prop)
     list.sort(function(a, b) {
-        return b.relevence - a.relevence
+        return b.relevence - a.relevence;
     });
 
-    return list
+    return list;
 }
 
 function concat(list, prop, filter) {
-    var value = []
+    var value = [];
 
     //print("Concat:", prop, length(list))
 
     for (var i = 0; i < length(list); i++) {
-        var item = getItem(list, i)
-        if (filter && !filter(item)) continue
+        var item = getItem(list, i);
+        if (filter && !filter(item))
+            continue;
 
         //print("Adding:", item[prop])
         if (item[prop].hasOwnProperty("length")) {
-            value = value.concat(item[prop])
+            value = value.concat(item[prop]);
         } else {
             for (var j = 0; j < item[prop].count; j++) {
-                value.push(getItem(item[prop], j))
+                value.push(getItem(item[prop], j));
             }
         }
     }
 
     //print("Concat:", prop, value, length(value))
-    return value
+    return value;
 }
 
 function getItem(model, index) {
-    var item = model.hasOwnProperty("get") ? model.get(index) : model[index]
+    var item = model.hasOwnProperty("get") ? model.get(index) : model[index];
     if (model.hasOwnProperty("get") && item.modelData)
-        item = item.modelData
+        item = item.modelData;
 
-    return item
+    return item;
 }
 
 function getItemByFilter(list, filter) {
     for (var i = 0; i < length(list); i++) {
-        var item = getItem(list, i)
+        var item = getItem(list, i);
         if (filter(item))
-            return item
+            return item;
     }
 
-    return null
+    return null;
 }
 
 function length(model) {
     if (model === undefined || model === null)
-        return 0
+        return 0;
     else
-        return model.hasOwnProperty("count") ? model.count : model.length
+        return model.hasOwnProperty("count") ? model.count : model.length;
 }
 
 function objectKeys(obj) {
-    var keys = []
+    var keys = [];
     for(var k in obj)
-        keys.push(k)
-    return keys
+        keys.push(k);
+    return keys;
 }

--- a/modules/Material/Extras/js/promises.js
+++ b/modules/Material/Extras/js/promises.js
@@ -34,85 +34,86 @@ function subclass(constructor, superConstructor) {
 // Promise class
 
 function Promise(delayed) {
-    this.thenHandlers = []
-    this.onDone = []
-    this.onError = []
-    this.info = {}
+    this.thenHandlers = [];
+    this.onDone = [];
+    this.onError = [];
+    this.info = {};
 
     if (delayed !== undefined)
-        this.code = delayed
-};
-
-Promise.prototype.then = function (handler) {
-    this.thenHandlers.push(handler)
-    return this
+        this.code = delayed;
 }
 
+Promise.prototype.then = function (handler) {
+    this.thenHandlers.push(handler);
+    return this;
+};
+
 Promise.prototype.done = function (onResolved) {
-    this.onDone.push(onResolved)
-    return this
+    this.onDone.push(onResolved);
+    return this;
 };
 
 Promise.prototype.error = function (onError) {
-    this.onError.push(onError)
-    return this
+    this.onError.push(onError);
+    return this;
 };
 
 Promise.prototype.resolve = function (value) {
+    var handler, i;
     //print("Success")
-    for (var i = 0; i < this.thenHandlers.length; i++) {
-        var handler = this.thenHandlers[i]
-        value = handler(value, this.info)
+    for (i = 0; i < this.thenHandlers.length; i++) {
+        handler = this.thenHandlers[i];
+        value = handler(value, this.info);
     }
 
-    for (var i = 0; i < this.onDone.length; i++) {
-        var handler = this.onDone[i]
-        handler(value, this.info)
+    for (i = 0; i < this.onDone.length; i++) {
+        handler = this.onDone[i];
+        handler(value, this.info);
     }
 };
 
 Promise.prototype.reject = function (error) {
     //print("Failure", error)
     for (var i = 0; i < this.onError.length; i++) {
-        var handler = this.onError[i]
-        handler(error, this.info)
+        var handler = this.onError[i];
+        handler(error, this.info);
     }
 };
 
 Promise.prototype.start = function(args) {
-    this.code(args)
-}
+    this.code(args);
+};
 
 // JoinedPromise class
 
-subclass(JoinedPromise, Promise)
+subclass(JoinedPromise, Promise);
 
 function JoinedPromise() {
     Promise.call(this);
 
-    this.promiseCount = 0
+    this.promiseCount = 0;
 }
 
 JoinedPromise.prototype.add = function(promise) {
-    this.promiseCount++
+    this.promiseCount++;
 
-    var join = this
+    var join = this;
 
     promise.done(function(data) {
-        join.promiseCount--
+        join.promiseCount--;
 
-        if (join.promiseCount == 0) {
-            print("All joined promises done!")
-            join.resolve()
+        if (join.promiseCount === 0) {
+            print("All joined promises done!");
+            join.resolve();
         }
-    })
+    });
 
     promise.error(function (error) {
-        join.promiseCount = -1
+        join.promiseCount = -1;
 
-        print("A joined promise failed, shortcutting to failure!")
-        join.reject(error)
-    })
+        print("A joined promise failed, shortcutting to failure!");
+        join.reject(error);
+    });
 
-    return this
-}
+    return this;
+};

--- a/modules/Material/Extras/js/utils.js
+++ b/modules/Material/Extras/js/utils.js
@@ -32,29 +32,29 @@ function generateID() {
                s4() + '-' + s4() + s4() + s4();
       };
     })()();
-    print(guid)
-    return guid
+    print(guid);
+    return guid;
 }
 
 function findRoot(obj) {
     while (obj.parent) {
-        obj = obj.parent
+        obj = obj.parent;
     }
 
-    return obj
+    return obj;
 }
 
 function findRootChild(obj, objectName) {
-    obj = findRoot(obj)
+    obj = findRoot(obj);
 
     var childs = new Array(0);
-    childs.push(obj)
+    childs.push(obj);
     while (childs.length > 0) {
         if (childs[0].objectName == objectName) {
-            return childs[0]
+            return childs[0];
         }
         for (var i in childs[0].data) {
-            childs.push(childs[0].data[i])
+            childs.push(childs[0].data[i]);
         }
         childs.splice(0, 1);
     }
@@ -64,13 +64,13 @@ function findRootChild(obj, objectName) {
 
 function findChild(obj,objectName) {
     var childs = new Array(0);
-    childs.push(obj)
+    childs.push(obj);
     while (childs.length > 0) {
         if (childs[0].objectName == objectName) {
-            return childs[0]
+            return childs[0];
         }
         for (var i in childs[0].data) {
-            childs.push(childs[0].data[i])
+            childs.push(childs[0].data[i]);
         }
         childs.splice(0, 1);
     }
@@ -82,46 +82,47 @@ function escapeHTML(html) {
 }
 
 function cherrypick(list, properties) {
+    var obj, prop, i;
 
     if (list instanceof Array) {
-        var result = []
+        var result = [];
 
-        for (var i = 0; i < list.length; i++) {
-            var item = list[i]
-            var obj = {}
+        for (i = 0; i < list.length; i++) {
+            var item = list[i];
+            obj = {};
             for (var j = 0; j < properties.length; j++) {
-                var prop = properties[j]
-                obj[prop] = item[prop]
+                prop = properties[j];
+                obj[prop] = item[prop];
             }
 
-            result.push(obj)
+            result.push(obj);
         }
 
-        return result
+        return result;
     } else {
-        var obj = {}
+        obj = {};
 
-        for (var i = 0; i < properties.length; i++) {
-            var prop = properties[i]
-            print(prop)
-            obj[prop] = list[prop]
+        for (i = 0; i < properties.length; i++) {
+            prop = properties[i];
+            print(prop);
+            obj[prop] = list[prop];
         }
 
-        return obj
+        return obj;
     }
 }
 
 function newObject(path, args, parent) {
     if (!args)
-        args = {}
+        args = {};
 
-    args.parent = parent
+    args.parent = parent;
 
     var component = Qt.createComponent(path);
     if (component.status === QtQuick.Component.Error) {
         // Error Handling
-        print("Unable to load object: " + path + "\n" + component.errorString())
-        return null
+        print("Unable to load object: " + path + "\n" + component.errorString());
+        return null;
     }
 
     return component.createObject(parent, args);


### PR DESCRIPTION
This fixes issue #260. The fixes made are basically 95% semicolons, 5% re-used variable declaration at the top of the function (because of js's scope strangeness).
I also replaced jslint by jshint for the following reasons:
 - jslint is less configurable and has (imho) stupid defaults: warns about post fix increment, global variables or functions (like print()) being undefined, and other useless things that make a "perfect" score near impossible.
 - jshint is more recent and has more support community support (and a nicer output).

The Travis Cl build will have to be modified to install jshint I guess. If replacing jslint by jshint isn't okay I'll revert.