### PR TITLE
fix(tabbar): Initialize tabs to empty

### DIFF
--- a/modules/Material/TabBar.qml
+++ b/modules/Material/TabBar.qml
@@ -26,7 +26,7 @@ Item {
 
     property bool centered: false
 
-	property var tabs
+	property var tabs: []
 	property int leftKeyline
 
 	property bool isLargeDevice: Device.type == Device.desktop || Device.type == Device.tablet


### PR DESCRIPTION
If the tabs variable aren't initialized the rest of the qml file doesn't work correctly.