### PR TITLE
[Page] Add a way to override the default behavior when the back key is pressed in Android

### DIFF
--- a/modules/Material/Page.qml
+++ b/modules/Material/Page.qml
@@ -149,6 +149,15 @@ FocusScope {
      */
     property string title
 
+    /*!
+        This signal is emitted when the Back button is released.
+        When handling this signal, use the \l {KeyEvent::}{accepted} property of the \a event
+        parameter to control whether this Page override the default behaviour.
+        The default is to ignore the event and pop the \l PageStack if this isn't a top level \l Page,
+        or exit the application if it is a top level \l Page.
+        If \e accepted is set to \c true, the default behaviour is overriden and this \l Page stays on the \l PageStack.
+        The corresponding handler is \c onBackReleased.
+    */
     signal backReleased(var event)
 
     /*!
@@ -180,8 +189,9 @@ FocusScope {
                 __actionBar.closeOverflowMenu();
                 event.accepted = true;
             } else {
+                // or signal the back button has been tapped
                 backReleased(event);
-                // or pop the page from the page stack
+                // and pop the page from the page stack if no handlers accepted the event
                 if (!event.accepted && pop()) {
                     event.accepted = true;
                 }

--- a/modules/Material/Page.qml
+++ b/modules/Material/Page.qml
@@ -149,6 +149,8 @@ FocusScope {
      */
     property string title
 
+    signal backReleased(var event)
+
     /*!
        Pop this page from the page stack. This does nothing if this page is not
        the current page on the page stack.
@@ -178,8 +180,9 @@ FocusScope {
                 __actionBar.closeOverflowMenu();
                 event.accepted = true;
             } else {
+                backReleased(event);
                 // or pop the page from the page stack
-                if (pop()) {
+                if (!event.accepted && pop()) {
                     event.accepted = true;
                 }
             }


### PR DESCRIPTION
This closes #200 

Now a `Page` can implement `onBackReleased` and set the `accepted` property of the passed event to `true` to override the default behavior and stay on the page stack.