### PR TITLE
Make it possible to do some TextField-related actions

### DIFF
--- a/demo/TextFieldDemo.qml
+++ b/demo/TextFieldDemo.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.0
 import QtQuick.Layouts 1.1
+import QtQuick.Controls 1.1 as Controls
 import Material 0.1
 
 Item {
@@ -33,6 +34,17 @@ Item {
             floatingLabel: true
             characterLimit: 10
             anchors.horizontalCenter: parent.horizontalCenter
+        }
+
+        TextField {
+            placeholderText: "Text Field with Menu"
+            anchors.horizontalCenter: parent.horizontalCenter
+            menu: Controls.Menu {
+                Controls.MenuItem {
+                    text: "Print \"awesome\""
+                    onTriggered: console.log("awesome");
+                }
+            }
         }
 
         TextField {

--- a/demo/TextFieldDemo.qml
+++ b/demo/TextFieldDemo.qml
@@ -62,5 +62,8 @@ Item {
                 }
             }
         }
+        TextArea {
+
+        }
     }
 }

--- a/modules/Material/Button.qml
+++ b/modules/Material/Button.qml
@@ -67,7 +67,7 @@ Controls.Button {
        The context of the button, which is used to control special styling of 
        buttons in dialogs or snackbars.
      */
-    property string context: "default" // or "dialog" or "snackbar"
+    property string context: "default" // "dialog", "snackbar" or "editmenu"
 
     /*!
        Set to \c true if the button is on a dark background

--- a/modules/Material/IconButton.qml
+++ b/modules/Material/IconButton.qml
@@ -37,8 +37,8 @@ Item {
 
     signal clicked
 
-    width: icon.width
-    height: icon.height
+    implicitWidth: icon.width
+    implicitHeight: icon.height
     enabled: action ? action.enabled : true
     opacity: enabled ? 1 : 0.6
 

--- a/modules/Material/TextArea.qml
+++ b/modules/Material/TextArea.qml
@@ -1,0 +1,37 @@
+/*
+ * QML Material - An application framework implementing Material Design.
+ * Copyright (C) 2014 Bogdan Cuza <bogdan.cuza@hotmail.com>
+ *               2015 Ricardo Vieira <ricardo.vieira@tecnico.ulisboa.pt>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
+import QtQuick.Controls.Styles.Material 0.1 as MaterialStyle
+import Material 0.1
+
+/*!
+   \qmltype TextArea
+   \inqmlmodule Material 0.1
+
+   \brief A text area input control.
+ */
+Controls.TextArea {
+
+    property color color: Theme.accentColor
+    property color errorColor: Palette.colors["red"]["500"]
+
+    style: MaterialStyle.TextAreaStyle {}
+}

--- a/modules/Material/qmldir
+++ b/modules/Material/qmldir
@@ -40,6 +40,7 @@ Switch 0.1 Switch.qml
 Tab 0.1 Tab.qml
 TabBar 0.1 TabBar.qml
 TabbedPage 0.1 TabbedPage.qml
+TextArea 0.1 TextArea.qml
 TextField 0.1 TextField.qml
 ThinDivider 0.1 ThinDivider.qml
 TimePicker 0.1 TimePicker.qml

--- a/modules/QtQuick/Controls/Styles/Material/ButtonStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/ButtonStyle.qml
@@ -92,6 +92,7 @@ ButtonStyle {
         implicitWidth: context == "dialog" 
                 ? Math.max(Units.dp(64), label.width + Units.dp(16))
                 : context == "snackbar" ? label.width + Units.dp(16)
+                : context == "editmenu" ? label.width
                                         : Math.max(Units.dp(88), label.width + Units.dp(32))
 
         Label {

--- a/modules/QtQuick/Controls/Styles/Material/MaterialEditMenu.qml
+++ b/modules/QtQuick/Controls/Styles/Material/MaterialEditMenu.qml
@@ -1,0 +1,188 @@
+/*
+ *   Copyright (C) 2015 by Aleix Pol Gonzalez <aleixpol@kde.org>
+ *   Copyright (C) 2015 by Marco Martin <mart@kde.org>
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as
+ *   published by the Free Software Foundation; either version 2, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Library General Public License for more details
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the
+ *   Free Software Foundation, Inc.,
+ *   51 Franklin Street, Fifth Floor, Boston, MA  2.010-1301, USA.
+ */
+
+import QtQuick 2.1
+import QtQuick.Controls 1.1
+import QtQuick.Controls.Styles 1.1
+import QtQuick.Layouts 1.0
+import Material 0.1
+
+Item {
+    id: root
+    anchors.fill: parent
+
+    property bool editing: true
+    onEditingChanged: {
+        updateCursorOpacity()
+    }
+    function updateCursorOpacity() {
+        var opacity = root.editing ? 0 : 1;
+        cursorHandle.opacity = opacity;
+        selectionHandle.opacity = opacity;
+    }
+    Component.onCompleted: updateCursorOpacity()
+
+//     https://www.google.com/design/spec/patterns/selection.html#selection-text-selection
+    Component {
+        id: editControls
+        Item {
+            id: popup
+            visible: input.activeFocus && !root.editing
+            z: 9999
+
+            Behavior on x { NumberAnimation { duration: 500; easing.type: Easing.InOutQuad } }
+
+            Component.onCompleted: {
+                var par = control
+                //heuristic: if a flickable is found in the parents,
+                //reparent to it, so it scrolls together
+                while (par.parent && par.parent.contentY === undefined) {
+                    par = par.parent
+                }
+
+                popup.parent = par
+            }
+
+            function popup(startRect) {
+//                 var selectedTextTopPadding = Units.dp(8);
+                var mapped = parent.mapFromItem(input, startRect.x, startRect.y);
+                var mapWidget = parent.mapFromItem(input.parent, input.x, input.y, input.width, input.height);
+
+                popup.x = Math.min(Math.max(mapWidget.x, mapped.x), mapWidget.x+mapWidget.width-bg.width);
+                popup.y = Math.max(0, mapped.y - bg.height);
+            }
+            function dismiss() {
+                popup.visible = false;
+            }
+
+            View {
+                id: bg
+                elevation: 1
+                anchors {
+                    fill: buttons
+                    topMargin: -Units.dp(12)
+                    bottomMargin: -Units.dp(14)
+                    leftMargin: -Units.dp(24)
+                    rightMargin: -Units.dp(16)
+                }
+            }
+
+            RowLayout {
+                id: buttons
+                spacing: Units.dp(32)
+                Button {
+                    text: qsTr("Cut")
+                    visible: input.selectedText != ""
+                    context: "editmenu"
+                    onClicked: {
+                        control.cut();
+                        select(input.cursorPosition, input.cursorPosition);
+                    }
+                }
+                Button {
+                    text: qsTr("Copy")
+                    visible: input.selectedText != ""
+                    context: "editmenu"
+                    onClicked: {
+                        control.copy();
+                        select(input.cursorPosition, input.cursorPosition);
+                    }
+                }
+                Button {
+                    text: qsTr("Paste")
+                    visible: input.canPaste
+                    context: "editmenu"
+                    onClicked: {
+                        control.paste();
+                    }
+                }
+                Button {
+                    text: qsTr("Select All")
+                    visible: input.text != ""
+                    context: "editmenu"
+                    onClicked: {
+                        control.selectAll();
+                    }
+                }
+
+                IconButton {
+                    iconName: "navigation/more_vert"
+                    visible: control.menu !== null
+                    onClicked: {
+                        getMenuInstance().popup()
+                    }
+                }
+            }
+        }
+    }
+
+    Connections {
+        target: mouseArea
+
+        onClicked: {
+            var pos = input.positionAt(mouse.x, mouse.y)
+            input.moveHandles(pos, pos)
+            input.activate()
+        }
+        onPressAndHold: {
+            root.editing = false;
+            var pos = input.positionAt(mouse.x, mouse.y)
+            input.moveHandles(pos, control.selectByMouse ? -1 : pos)
+            input.activate()
+        }
+    }
+
+    Connections {
+        target: input
+        onSelectionStartChanged: popupTimer.restart()
+        onSelectionEndChanged: popupTimer.restart()
+        onActiveFocusChanged: {
+            popupTimer.restart()
+            root.editing = true;
+        }
+        onTextChanged: root.editing = true;
+    }
+
+    Connections {
+        target: flickable
+        onMovingChanged: popupTimer.restart()
+    }
+
+    property Item editControlsInstance: null
+    function getEditControlsInstance() {
+        // Lazy load the view when first requested
+        if (!editControlsInstance) {
+            editControlsInstance = editControls.createObject(control);
+        }
+        return editControlsInstance;
+    }
+
+    Timer {
+        id: popupTimer
+        interval: 200
+        onTriggered: {
+            if (input.canPaste || selectionStart !== selectionEnd) {
+                var startRect = input.positionToRectangle(input.selectionStart);
+
+                getEditControlsInstance().popup(startRect);
+            }
+        }
+    }
+}

--- a/modules/QtQuick/Controls/Styles/Material/MaterialEditMenu.qml
+++ b/modules/QtQuick/Controls/Styles/Material/MaterialEditMenu.qml
@@ -56,11 +56,10 @@ Item {
                 var mapped = parent.mapFromItem(input, startRect.x, startRect.y);
                 var mapWidget = parent.mapFromItem(input.parent, input.x, input.y, input.width, input.height);
 
-                popup.x = Math.min(Math.max(mapWidget.x, mapped.x), mapWidget.x+mapWidget.width-bg.width);
+                popup.x = Math.min(Math.max(mapWidget.x, mapped.x-bg.anchors.leftMargin), mapWidget.x+mapWidget.width-bg.width);
                 popup.y = Math.max(0, mapped.y - bg.height);
-            }
-            function dismiss() {
-                popup.visible = false;
+
+                console.log("showing...", popup.x, popup.y, parent)
             }
 
             View {

--- a/modules/QtQuick/Controls/Styles/Material/MaterialEditMenu.qml
+++ b/modules/QtQuick/Controls/Styles/Material/MaterialEditMenu.qml
@@ -21,6 +21,7 @@
 import QtQuick 2.1
 import QtQuick.Controls 1.1
 import QtQuick.Controls.Styles 1.1
+import QtQuick.Window 2.1
 import QtQuick.Layouts 1.0
 import Material 0.1
 
@@ -49,19 +50,9 @@ Item {
 
             Behavior on x { NumberAnimation { duration: 500; easing.type: Easing.InOutQuad } }
 
-            Component.onCompleted: {
-                var par = control
-                //heuristic: if a flickable is found in the parents,
-                //reparent to it, so it scrolls together
-                while (par.parent && par.parent.contentY === undefined) {
-                    par = par.parent
-                }
-
-                popup.parent = par
-            }
+            parent: Window.contentItem
 
             function popup(startRect) {
-//                 var selectedTextTopPadding = Units.dp(8);
                 var mapped = parent.mapFromItem(input, startRect.x, startRect.y);
                 var mapWidget = parent.mapFromItem(input.parent, input.x, input.y, input.width, input.height);
 
@@ -178,7 +169,7 @@ Item {
         id: popupTimer
         interval: 200
         onTriggered: {
-            if (input.canPaste || selectionStart !== selectionEnd) {
+            if (!root.editing && (input.canPaste || selectionStart !== selectionEnd)) {
                 var startRect = input.positionToRectangle(input.selectionStart);
 
                 getEditControlsInstance().popup(startRect);

--- a/modules/QtQuick/Controls/Styles/Material/TextAreaStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/TextAreaStyle.qml
@@ -1,0 +1,145 @@
+/*
+ * QML Material - An application framework implementing Material Design.
+ * Copyright (C) 2015 Ricardo Vieira <ricardo.vieira@tecnico.ulisboa.pt>
+ *               2015 Michael Spencer <sonrisesoftware@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.0
+import QtQuick.Controls.Styles 1.3
+import QtQuick.Layouts 1.1
+import Material 0.1
+
+TextFieldStyle {
+    id: style
+
+    padding {
+        left: 0
+        right: 0
+        top: 0
+        bottom: 0
+    }
+
+    font {
+        family: "Roboto"
+        pixelSize: Units.dp(16)
+    }
+
+    renderType: Text.QtRendering
+    placeholderTextColor: "transparent"
+    selectedTextColor: "white"
+    selectionColor: control.hasOwnProperty("color") ? control.color : Theme.accentColor
+    textColor: Theme.light.textColor
+
+    //make sure to QT_QUICK_CONTROLS_MOBILE=ON to properly test this
+    property Component __editMenu: MaterialEditMenu {
+        id: menu
+    }
+
+    property Component __cursorHandle: TextHandle {
+        side: control.selectionEnd - control.selectionStart
+        color: Palette.colors["blue"]["400"]
+    }
+
+    property Component __selectionHandle: TextHandle {
+        side: control.selectionStart - control.selectionEnd
+        color: Palette.colors["blue"]["400"]
+    }
+
+
+    background : Item {
+        id: background
+
+        property color color: control.hasOwnProperty("color") ? control.color : Theme.accentColor
+        property color errorColor: control.hasOwnProperty("errorColor")
+                ? control.errorColor : Palette.colors["red"]["500"]
+
+        Rectangle {
+            id: underline
+            color: background.hasError ? background.errorColor
+                                    : control.activeFocus ? background.color
+                                                          : Theme.light.hintColor
+
+            height: control.activeFocus ? Units.dp(2) : Units.dp(1)
+            visible: background.showBorder
+
+            anchors {
+                left: parent.left
+                right: parent.right
+                bottom: parent.bottom
+            }
+
+            Behavior on height {
+                NumberAnimation { duration: 200 }
+            }
+
+            Behavior on color {
+                ColorAnimation { duration: 200 }
+            }
+        }
+
+
+        Label {
+            id: fieldPlaceholder
+
+            anchors.verticalCenter: parent.verticalCenter
+            text: control.placeholderText
+            font.pixelSize: Units.dp(16)
+            anchors.margins: -Units.dp(12)
+            color: background.hasError ? background.errorColor
+                                  : control.activeFocus && control.text !== ""
+                                        ? background.color : Theme.light.hintColor
+
+            states: [
+                State {
+                    name: "floating"
+                    when: control.displayText.length > 0 && background.floatingLabel
+                    AnchorChanges {
+                        target: fieldPlaceholder
+                        anchors.verticalCenter: undefined
+                        anchors.top: parent.top
+                    }
+                    PropertyChanges {
+                        target: fieldPlaceholder
+                        font.pixelSize: Units.dp(12)
+                    }
+                },
+                State {
+                    name: "hidden"
+                    when: control.displayText.length > 0 && !background.floatingLabel
+                    PropertyChanges {
+                        target: fieldPlaceholder
+                        visible: false
+                    }
+                }
+            ]
+
+            transitions: [
+                Transition {
+                    id: floatingTransition
+                    enabled: false
+                    AnchorAnimation {
+                        duration: 200
+                    }
+                    NumberAnimation {
+                        duration: 200
+                        property: "font.pixelSize"
+                    }
+                }
+            ]
+
+            Component.onCompleted: floatingTransition.enabled = true
+        }
+    }
+}

--- a/modules/QtQuick/Controls/Styles/Material/TextFieldStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/TextFieldStyle.qml
@@ -65,7 +65,7 @@ TextFieldStyle {
         property color errorColor: control.hasOwnProperty("errorColor")
                 ? control.errorColor : Palette.colors["red"]["500"]
         property string helperText: control.hasOwnProperty("helperText") ? control.helperText : ""
-        property bool floatingLabel: control.hasOwnProperty("floatingLabel") ? control.floatingLabel : ""
+        property bool floatingLabel: control.hasOwnProperty("floatingLabel") ? control.floatingLabel : false
         property bool hasError: control.hasOwnProperty("hasError")
                 ? control.hasError : characterLimit && control.length > characterLimit
         property int characterLimit: control.hasOwnProperty("characterLimit") ? control.characterLimit : 0
@@ -149,6 +149,7 @@ TextFieldStyle {
         }
 
         RowLayout {
+            id: helper
             anchors {
                 left: parent.left
                 right: parent.right

--- a/modules/QtQuick/Controls/Styles/Material/TextFieldStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/TextFieldStyle.qml
@@ -42,6 +42,22 @@ TextFieldStyle {
     selectionColor: control.hasOwnProperty("color") ? control.color : Theme.accentColor
     textColor: Theme.light.textColor
 
+    //make sure to QT_QUICK_CONTROLS_MOBILE=ON to properly test this
+    property Component __editMenu: MaterialEditMenu {
+        id: menu
+    }
+
+    property Component __cursorHandle: TextHandle {
+        side: control.selectionEnd - control.selectionStart
+        color: Palette.colors["blue"]["400"]
+    }
+
+    property Component __selectionHandle: TextHandle {
+        side: control.selectionStart - control.selectionEnd
+        color: Palette.colors["blue"]["400"]
+    }
+
+
     background : Item {
         id: background
 

--- a/modules/QtQuick/Controls/Styles/Material/TextHandle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/TextHandle.qml
@@ -1,0 +1,64 @@
+/*
+ *   Copyright (C) 2015 by Aleix Pol Gonzalez <aleixpol@kde.org>
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Library General Public License as
+ *   published by the Free Software Foundation; either version 2, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Library General Public License for more details
+ *
+ *   You should have received a copy of the GNU Library General Public
+ *   License along with this program; if not, write to the
+ *   Free Software Foundation, Inc.,
+ *   51 Franklin Street, Fifth Floor, Boston, MA  2.010-1301, USA.
+ */
+
+import QtQuick 2.1
+import Material 0.1
+
+Rectangle {
+    id: root
+    property int side: 0 //-1 left, 0 center, 1 right
+
+    width: Units.dp(22)
+    height: Units.dp(22)
+
+    radius: width
+    y: styleData.lineHeight
+
+    Rectangle {
+        id: rect
+        width: parent.width/2
+        height: parent.height/2
+        color: parent.color
+    }
+
+    states: [
+        State {
+            when: side<0
+            name: "right"
+            PropertyChanges { target: root; x: -width}
+            AnchorChanges { target: rect; anchors.right: parent.right }
+        },
+        State {
+            when: side>0
+            name: "left"
+            AnchorChanges { target: rect; anchors.left: parent.left }
+        },
+        State {
+            when: side==0
+            name: "center"
+            PropertyChanges { target: rect; rotation: 45 }
+            PropertyChanges { target: rect; width: root.width/Math.SQRT2 }
+            PropertyChanges { target: rect; height: rect.width }
+            PropertyChanges { target: rect; x: (root.width-rect.width)/2 }
+
+            PropertyChanges { target: root; y: styleData.lineHeight/*+root.height/2*/ }
+            PropertyChanges { target: root; x: -root.width/2 }
+        }
+    ]
+}

--- a/modules/QtQuick/Controls/Styles/Material/qmldir
+++ b/modules/QtQuick/Controls/Styles/Material/qmldir
@@ -9,3 +9,4 @@ ToolButtonStyle.qml 0.1 ToolButtonStyle.qml
 RadioButtonStyle 0.1 RadioButtonStyle.qml
 SliderStyle 0.1 SliderStyle.qml
 TextFieldStyle 0.1 TextFieldStyle.qml
+TextHandle 0.1 TextHandle.qml

--- a/modules/QtQuick/Controls/Styles/Material/qmldir
+++ b/modules/QtQuick/Controls/Styles/Material/qmldir
@@ -8,5 +8,6 @@ ToolBarStyle.qml 0.1 ToolBarStyle.qml
 ToolButtonStyle.qml 0.1 ToolButtonStyle.qml
 RadioButtonStyle 0.1 RadioButtonStyle.qml
 SliderStyle 0.1 SliderStyle.qml
+TextAreaStyle 0.1 TextAreaStyle.qml
 TextFieldStyle 0.1 TextFieldStyle.qml
 TextHandle 0.1 TextHandle.qml


### PR DESCRIPTION
Introduces copy, paste and select all when a text field is selected.
Uses the __editMenu property introduced in Qt 5.6.
Integrates the text field custom menu, as shown in the demo.

Addresses bug #300, at least as a first iteration.
