### PR TITLE
Normalize imports to Qt 5.4

### DIFF
--- a/demo/BottomSheetDemo.qml
+++ b/demo/BottomSheetDemo.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import Material.ListItems 0.1
 

--- a/demo/ButtonDemo.qml
+++ b/demo/ButtonDemo.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
-import QtQuick.Controls 1.2 as Controls
+import QtQuick.Controls 1.3 as Controls
 
 Item {
 

--- a/demo/CheckBoxDemo.qml
+++ b/demo/CheckBoxDemo.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Material 0.1
 

--- a/demo/ColorPaletteDemo.qml
+++ b/demo/ColorPaletteDemo.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Material 0.1
 

--- a/demo/CustomIconsDemo.qml
+++ b/demo/CustomIconsDemo.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import Material.ListItems 0.1 as ListItem
 

--- a/demo/DatePickerDemo.qml
+++ b/demo/DatePickerDemo.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Material 0.1
 import Material.ListItems 0.1 as ListItem

--- a/demo/DialogDemo.qml
+++ b/demo/DialogDemo.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as QuickControls
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as QuickControls
 import Material 0.1
 import Material.Extras 0.1
 

--- a/demo/FormsDemo.qml
+++ b/demo/FormsDemo.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Material 0.1
 import Material.ListItems 0.1 as ListItem

--- a/demo/IconsDemo.qml
+++ b/demo/IconsDemo.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import Material.ListItems 0.1 as ListItem
 import Material.Extras 0.1

--- a/demo/ListItemsDemo.qml
+++ b/demo/ListItemsDemo.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import Material.ListItems 0.1 as ListItem
 import Material.Extras 0.1

--- a/demo/PageStackDemo.qml
+++ b/demo/PageStackDemo.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import Material.Extras 0.1
 

--- a/demo/ProgressBarDemo.qml
+++ b/demo/ProgressBarDemo.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Material 0.1
 

--- a/demo/RadioButtonDemo.qml
+++ b/demo/RadioButtonDemo.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import QtQuick.Controls 1.2 as QuickControls
+import QtQuick.Controls 1.3 as QuickControls
 import Material 0.1
 
 ColumnLayout {

--- a/demo/SliderDemo.qml
+++ b/demo/SliderDemo.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Material 0.1
 

--- a/demo/SubPage.qml
+++ b/demo/SubPage.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.2
+import QtQuick 2.4
 import Material 0.1
 import Material.ListItems 0.1 as ListItem
 

--- a/demo/SwitchDemo.qml
+++ b/demo/SwitchDemo.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Material 0.1
 

--- a/demo/TextFieldDemo.qml
+++ b/demo/TextFieldDemo.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Material 0.1
 

--- a/demo/TimePickerDemo.qml
+++ b/demo/TimePickerDemo.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 
 

--- a/demo/main.qml
+++ b/demo/main.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.2
+import QtQuick 2.4
 import Material 0.1
 import Material.ListItems 0.1 as ListItem
 

--- a/modules/Material/Action.qml
+++ b/modules/Material/Action.qml
@@ -15,8 +15,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
 /*!
    \qmltype Action
    \inqmlmodule Material 0.1

--- a/modules/Material/ActionBar.qml
+++ b/modules/Material/ActionBar.qml
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Material 0.1
 import Material.Extras 0.1

--- a/modules/Material/ActionButton.qml
+++ b/modules/Material/ActionButton.qml
@@ -15,9 +15,9 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
-import QtQuick.Controls.Styles 1.2 as ControlStyles
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
+import QtQuick.Controls.Styles 1.3 as ControlStyles
 import Material 0.1
 import QtGraphicalEffects 1.0
 

--- a/modules/Material/AppTheme.qml
+++ b/modules/Material/AppTheme.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 
 /*!

--- a/modules/Material/ApplicationWindow.qml
+++ b/modules/Material/ApplicationWindow.qml
@@ -15,9 +15,9 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
-import QtQuick.Window 2.0
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
+import QtQuick.Window 2.2
 import Material 0.1
 import Material.Extras 0.1
 
@@ -33,7 +33,7 @@ import Material.Extras 0.1
    Here is a short working example of an application:
 
    \qml
-   import QtQuick 2.0
+   import QtQuick 2.4
    import Material 0.1
 
    ApplicationWindow {

--- a/modules/Material/AwesomeIcon.qml
+++ b/modules/Material/AwesomeIcon.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import 'awesome.js' as Awesome
 

--- a/modules/Material/BottomActionSheet.qml
+++ b/modules/Material/BottomActionSheet.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import Material.ListItems 0.1 as ListItem
 

--- a/modules/Material/BottomSheet.qml
+++ b/modules/Material/BottomSheet.qml
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 
 /*!

--- a/modules/Material/Button.qml
+++ b/modules/Material/Button.qml
@@ -15,8 +15,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
 import QtQuick.Controls.Styles.Material 0.1 as MaterialStyle
 import Material 0.1
 

--- a/modules/Material/Card.qml
+++ b/modules/Material/Card.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 
 /*!

--- a/modules/Material/CheckBox.qml
+++ b/modules/Material/CheckBox.qml
@@ -15,8 +15,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
 import QtQuick.Controls.Styles.Material 0.1 as MaterialStyle
 import Material 0.1
 

--- a/modules/Material/DatePicker.qml
+++ b/modules/Material/DatePicker.qml
@@ -20,7 +20,7 @@ import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 1.3 as Controls
 import QtQuick.Controls.Styles.Material 0.1 as MaterialStyle
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Controls.Styles 1.3
 import QtQuick.Controls.Private 1.0
 import Material 0.1
 

--- a/modules/Material/Device.qml
+++ b/modules/Material/Device.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 
 pragma Singleton
 

--- a/modules/Material/Dialog.qml
+++ b/modules/Material/Dialog.qml
@@ -18,7 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Material 0.1
 import Material.Extras 0.1

--- a/modules/Material/Dropdown.qml
+++ b/modules/Material/Dropdown.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Window 2.2
 import Material 0.1
 import Material.Extras 0.1

--- a/modules/Material/Extras/AutomaticGrid.qml
+++ b/modules/Material/Extras/AutomaticGrid.qml
@@ -17,7 +17,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 
 Grid {
     id: grid

--- a/modules/Material/Extras/CircleImage.qml
+++ b/modules/Material/Extras/CircleImage.qml
@@ -17,7 +17,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.4
 import Material.Extras 0.1 as Extras
 import QtGraphicalEffects 1.0
 

--- a/modules/Material/Extras/CircleMask.qml
+++ b/modules/Material/Extras/CircleMask.qml
@@ -17,7 +17,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.4
 import QtGraphicalEffects 1.0
 
 Item {

--- a/modules/Material/Extras/ColumnFlow.qml
+++ b/modules/Material/Extras/ColumnFlow.qml
@@ -17,7 +17,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 
 /*
 example usage:

--- a/modules/Material/Extras/Document.qml
+++ b/modules/Material/Extras/Document.qml
@@ -17,7 +17,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 
 Object {
     id: document

--- a/modules/Material/Extras/Image.qml
+++ b/modules/Material/Extras/Image.qml
@@ -17,7 +17,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.3
+import QtQuick 2.4
 
 Image {
   id: image

--- a/modules/Material/Extras/Object.qml
+++ b/modules/Material/Extras/Object.qml
@@ -17,7 +17,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 
 QtObject {
     id: object

--- a/modules/Material/Extras/js/httplib.js
+++ b/modules/Material/Extras/js/httplib.js
@@ -61,7 +61,7 @@ function request(path, call, args, timeout) {
 
     if(timeout !== undefined) {
         console.log("Creating timer.");
-        timer = Qt.createQmlObject("import QtQuick 2.3; Timer {interval: " + timeout + "; repeat: false; running: true;}", Qt.application, "XHRTimer");
+        timer = Qt.createQmlObject("import QtQuick 2.4; Timer {interval: " + timeout + "; repeat: false; running: true;}", Qt.application, "XHRTimer");
         timer.triggered.connect(function() {
             doc.hasTimeout = true;
             doc.abort();

--- a/modules/Material/Extras/js/utils.js
+++ b/modules/Material/Extras/js/utils.js
@@ -18,7 +18,7 @@
  */
 
 .pragma library
-.import QtQuick 2.0 as QtQuick
+.import QtQuick 2.4 as QtQuick
 
 function generateID() {
     var guid = (function() {

--- a/modules/Material/Icon.qml
+++ b/modules/Material/Icon.qml
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.3
-import QtQuick.Window 2.0
+import QtQuick 2.4
+import QtQuick.Window 2.2
 import Material 0.1
 import QtGraphicalEffects 1.0
 

--- a/modules/Material/IconButton.qml
+++ b/modules/Material/IconButton.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import Material.Extras 0.1
 

--- a/modules/Material/Ink.qml
+++ b/modules/Material/Ink.qml
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import Material.Extras 0.1
 

--- a/modules/Material/InputDialog.qml
+++ b/modules/Material/InputDialog.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 
 /*!

--- a/modules/Material/Label.qml
+++ b/modules/Material/Label.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 
 /*!

--- a/modules/Material/ListItems/BaseListItem.qml
+++ b/modules/Material/ListItems/BaseListItem.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import ".."
 
 /*!

--- a/modules/Material/ListItems/Divider.qml
+++ b/modules/Material/ListItems/Divider.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 
 /*!

--- a/modules/Material/ListItems/SimpleMenu.qml
+++ b/modules/Material/ListItems/SimpleMenu.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import Material.Extras 0.1
 

--- a/modules/Material/ListItems/Standard.qml
+++ b/modules/Material/ListItems/Standard.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtGraphicalEffects 1.0
 import QtQuick.Layouts 1.1
 import Material 0.1

--- a/modules/Material/ListItems/Subheader.qml
+++ b/modules/Material/ListItems/Subheader.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 
 /*!

--- a/modules/Material/ListItems/Subtitled.qml
+++ b/modules/Material/ListItems/Subtitled.qml
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import ".."
 

--- a/modules/Material/MainView.qml
+++ b/modules/Material/MainView.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Window 2.2
 import Material 0.1
 

--- a/modules/Material/MaterialAnimation.qml
+++ b/modules/Material/MaterialAnimation.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 
 pragma Singleton
 

--- a/modules/Material/MenuField.qml
+++ b/modules/Material/MenuField.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.2
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 
 import Material 0.1

--- a/modules/Material/NavigationDrawer.qml
+++ b/modules/Material/NavigationDrawer.qml
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 
 /*!

--- a/modules/Material/Object.qml
+++ b/modules/Material/Object.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 
 /*!
    \qmltype Object

--- a/modules/Material/OverlayLayer.qml
+++ b/modules/Material/OverlayLayer.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 
 /*!
    \qmltype OverlayLayer

--- a/modules/Material/OverlayView.qml
+++ b/modules/Material/OverlayView.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import Material.Extras 0.1
 

--- a/modules/Material/Page.qml
+++ b/modules/Material/Page.qml
@@ -16,8 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
 import Material 0.1
 
 /*!
@@ -29,7 +29,7 @@ import Material 0.1
    Example:
 
    \qml
-   import QtQuick 2.0
+   import QtQuick 2.4
    import Material 0.1
 
    Page {

--- a/modules/Material/PageSidebar.qml
+++ b/modules/Material/PageSidebar.qml
@@ -15,8 +15,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
 import Material 0.1
 
 /*!

--- a/modules/Material/PageStack.qml
+++ b/modules/Material/PageStack.qml
@@ -15,8 +15,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
 import Material 0.1
 
 /*!

--- a/modules/Material/Palette.qml
+++ b/modules/Material/Palette.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 
 pragma Singleton

--- a/modules/Material/Popover.qml
+++ b/modules/Material/Popover.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import Material.Extras 0.1
 

--- a/modules/Material/PopupBase.qml
+++ b/modules/Material/PopupBase.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Window 2.2
 import Material 0.1
 import Material.Extras 0.1

--- a/modules/Material/ProgressBar.qml
+++ b/modules/Material/ProgressBar.qml
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Controls 1.3 as Controls
 import QtQuick.Controls.Styles.Material 0.1 as MaterialStyle
 import Material 0.1

--- a/modules/Material/ProgressCircle.qml
+++ b/modules/Material/ProgressCircle.qml
@@ -15,8 +15,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.2
-import QtQuick.Window 2.0
+import QtQuick 2.4
+import QtQuick.Window 2.2
 import QtQuick.Controls 1.3 as Controls
 import QtQuick.Controls.Styles 1.3 as Styles
 import Material 0.1

--- a/modules/Material/RadioButton.qml
+++ b/modules/Material/RadioButton.qml
@@ -16,8 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
 import QtQuick.Controls.Styles.Material 0.1 as MaterialStyle
 import Material 0.1
 

--- a/modules/Material/Scrollbar.qml
+++ b/modules/Material/Scrollbar.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 
 /*!
    \qmltype Scrollbar

--- a/modules/Material/Sidebar.qml
+++ b/modules/Material/Sidebar.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import "ListItems" as ListItem
 

--- a/modules/Material/Slider.qml
+++ b/modules/Material/Slider.qml
@@ -16,9 +16,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
-import QtQuick.Controls 1.2 as Controls
+import QtQuick.Controls 1.3 as Controls
 import QtQuick.Controls.Styles.Material 0.1 as MaterialStyle
 
 /*!

--- a/modules/Material/Snackbar.qml
+++ b/modules/Material/Snackbar.qml
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.3
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 import Material 0.1
 

--- a/modules/Material/Switch.qml
+++ b/modules/Material/Switch.qml
@@ -15,9 +15,9 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
-import QtQuick.Controls.Styles 1.2 as ControlStyles
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
+import QtQuick.Controls.Styles 1.3 as ControlStyles
 
 import Material 0.1
 

--- a/modules/Material/Tab.qml
+++ b/modules/Material/Tab.qml
@@ -15,8 +15,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
 
 /*!
    \qmltype Tab

--- a/modules/Material/TabBar.qml
+++ b/modules/Material/TabBar.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.2
+import QtQuick 2.4
 import QtQuick.Layouts 1.1
 
 import Material 0.1

--- a/modules/Material/TabbedPage.qml
+++ b/modules/Material/TabbedPage.qml
@@ -15,9 +15,9 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
-import QtQuick.Controls.Styles 1.2 as Styles
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
+import QtQuick.Controls.Styles 1.3 as Styles
 
 /*!
    \qmltype Tab

--- a/modules/Material/Theme.qml
+++ b/modules/Material/Theme.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 
 pragma Singleton
 

--- a/modules/Material/ThemePalette.qml
+++ b/modules/Material/ThemePalette.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 
 /*!
    \qmltype Theme

--- a/modules/Material/ThinDivider.qml
+++ b/modules/Material/ThinDivider.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 
 /*!
    \qmltype ThinDivider

--- a/modules/Material/TimePicker.qml
+++ b/modules/Material/TimePicker.qml
@@ -20,8 +20,8 @@
 import QtQuick 2.4
 import Material 0.1
 import Material.Extras 0.1
-import QtQuick.Controls 1.2 as QuickControls
-import QtQuick.Controls.Styles 1.2
+import QtQuick.Controls 1.3 as QuickControls
+import QtQuick.Controls.Styles 1.3
 
 FocusScope {
     id: timePicker

--- a/modules/Material/TimePickerDialog.qml
+++ b/modules/Material/TimePickerDialog.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 
 Dialog {

--- a/modules/Material/Toolbar.qml
+++ b/modules/Material/Toolbar.qml
@@ -15,8 +15,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
-import QtQuick.Controls 1.2 as Controls
+import QtQuick 2.4
+import QtQuick.Controls 1.3 as Controls
 import QtQuick.Layouts 1.1
 import Material 0.1
 

--- a/modules/Material/Tooltip.qml
+++ b/modules/Material/Tooltip.qml
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import Material 0.1
 import Material.Extras 0.1
 

--- a/modules/Material/Units.qml
+++ b/modules/Material/Units.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 
 pragma Singleton
 
@@ -32,7 +32,7 @@ pragma Singleton
    Here is a short example:
 
    \qml
-   import QtQuick 2.0
+   import QtQuick 2.4
    import Material 0.1
 
    Rectangle {

--- a/modules/Material/View.qml
+++ b/modules/Material/View.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtGraphicalEffects 1.0
 import Material 0.1
 

--- a/modules/Material/Wave.qml
+++ b/modules/Material/Wave.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 
 /*!
    \qmltype Wave

--- a/modules/Material/Window.qml
+++ b/modules/Material/Window.qml
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.2
+import QtQuick 2.4
 import Material 0.1
 import QtQuick.Window 2.2
 
@@ -29,7 +29,7 @@ import QtQuick.Window 2.2
    Here is a short working example of an application:
 
    \qml
-   import QtQuick 2.0
+   import QtQuick 2.4
    import Material 0.1
 
    Window {

--- a/modules/QtQuick/Controls/Styles/Material/ApplicationWindowStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/ApplicationWindowStyle.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Controls.Styles 1.3
 import Material 0.1
 

--- a/modules/QtQuick/Controls/Styles/Material/ButtonStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/ButtonStyle.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Controls.Styles 1.3
 import Material 0.1
 

--- a/modules/QtQuick/Controls/Styles/Material/CheckBoxStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/CheckBoxStyle.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Controls.Styles 1.3
 import Material 0.1
 

--- a/modules/QtQuick/Controls/Styles/Material/ProgressBarStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/ProgressBarStyle.qml
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Controls.Styles 1.3
 import Material 0.1
 

--- a/modules/QtQuick/Controls/Styles/Material/RadioButtonStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/RadioButtonStyle.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Controls.Styles 1.3
 import Material 0.1
 

--- a/modules/QtQuick/Controls/Styles/Material/SliderStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/SliderStyle.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Controls.Styles 1.3
 import Material 0.1
 

--- a/modules/QtQuick/Controls/Styles/Material/SwitchStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/SwitchStyle.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Controls.Styles 1.3
 import Material 0.1
 

--- a/modules/QtQuick/Controls/Styles/Material/TextFieldStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/TextFieldStyle.qml
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Controls.Styles 1.3
 import QtQuick.Layouts 1.1
 import Material 0.1

--- a/modules/QtQuick/Controls/Styles/Material/ToolBarStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/ToolBarStyle.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Controls.Styles 1.3
 import Material 0.1
 

--- a/modules/QtQuick/Controls/Styles/Material/ToolButtonStyle.qml
+++ b/modules/QtQuick/Controls/Styles/Material/ToolButtonStyle.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.0
+import QtQuick 2.4
 import QtQuick.Controls.Styles 1.3
 import Material 0.1
 import "../Base/"

--- a/normalize_imports.sh
+++ b/normalize_imports.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+ROOT=$1
+VERSION=$2
+
+for F in  $(grep -rl "${ROOT}" .)
+do
+    sed -i -r "s:import ${ROOT} [0-9]+.[0-9]+:import ${ROOT} ${VERSION}:g" $F
+done

--- a/normalize_imports.sh
+++ b/normalize_imports.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 ROOT=$1
 VERSION=$2

--- a/tests/qml-materials.qml
+++ b/tests/qml-materials.qml
@@ -15,8 +15,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.2
-import QtQuick.Window 2.0
+import QtQuick 2.4
+import QtQuick.Window 2.2
 import "ListItems" as ListItem
 
 Rectangle {

--- a/tests/tst_actionbar.qml
+++ b/tests/tst_actionbar.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.2
+import QtQuick 2.4
 import QtTest 1.0
 import Material 0.1
 

--- a/tests/tst_card.qml
+++ b/tests/tst_card.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.2
+import QtQuick 2.4
 import QtTest 1.0
 import Material 0.1
 

--- a/tests/tst_document.qml
+++ b/tests/tst_document.qml
@@ -16,7 +16,7 @@
 * You should have received a copy of the GNU General Public License
 * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtTest 1.0
 import Material.Extras 0.1
 

--- a/tests/tst_httplib.qml
+++ b/tests/tst_httplib.qml
@@ -16,7 +16,7 @@
 * You should have received a copy of the GNU General Public License
 * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtTest 1.0
 import Material.Extras 0.1
 

--- a/tests/tst_pagestack.qml
+++ b/tests/tst_pagestack.qml
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.2
+import QtQuick 2.4
 import QtTest 1.0
 import Material 0.1
 

--- a/tests/tst_promise.qml
+++ b/tests/tst_promise.qml
@@ -16,7 +16,7 @@
 * You should have received a copy of the GNU General Public License
 * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.4
 import QtTest 1.0
 import Material.Extras 0.1
 


### PR DESCRIPTION
This is a big commit that actually does VERY little.  There are two parts.  One is a shell script that will scan files and look for `import Foo x.y` and replace `Foo`'s `x.y` with a desired version.  This just makes everything consistent and is nice for Qt creator's code completion.   The second part is just washing the current source base through the script so that it is in line with Qt 5.4.
