### PR TITLE
Use Qt 5.4.2 in travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install:
   - "sh -e /etc/init.d/xvfb start"
 
 install:
-  - sudo add-apt-repository -y ppa:beineri/opt-qt541
+  - sudo add-apt-repository -y ppa:beineri/opt-qt542
   - sudo apt-get update
   - sudo apt-get -y install pep8 pyflakes python python-pip npm
   - sudo apt-get -y install qt54declarative

--- a/tests/tst_actionbar.qml
+++ b/tests/tst_actionbar.qml
@@ -137,7 +137,7 @@ Rectangle {
             compare(action4Spy.count, 0)
             mouseClick(button, 10, 10)
 
-            wait(400) // Wait for the overflow to fully open
+            wait(800) // Wait for the overflow to fully open
 
             verify(overflow.showing)
             mouseClick(listItem, 10, 10)


### PR DESCRIPTION
5.4.1 is no longer in the beineri PPA.

test_click_action_in_overflow has been modified to wait
longer as 400 is not long enough under 5.4.2.

- Fixes #316