### PR TITLE
[Ink] set hoverEnabled to false on mobile

### DIFF
--- a/modules/Material/Ink.qml
+++ b/modules/Material/Ink.qml
@@ -30,7 +30,7 @@ MouseArea {
     id: view
 
     clip: true
-    hoverEnabled: enabled
+    hoverEnabled: !Device.isMobile
     z: 2
 
     property int startRadius: circular ? width/10 : width/6


### PR DESCRIPTION
This fixes #321 
The problem is that when a MouseArea has hoverEnabled to true, only a mouse move outside the area will set containsMouse to false. On a touch device this can only happen when you move the touch outside while staying pressed, not by simply releasing the touch.
Maybe this should be reported upstream to Qt.