### PR TITLE
Add fillMode property to CircleImage

### DIFF
--- a/modules/Material/Extras/CircleImage.qml
+++ b/modules/Material/Extras/CircleImage.qml
@@ -30,6 +30,7 @@ Item {
     property alias sourceSize: image.sourceSize
     property alias asynchronous: image.asynchronous
     property alias cache: image.cache
+    property alias fillMode: image.fillMode
 
     width: image.implicitWidth
     height: image.implicitHeight


### PR DESCRIPTION
There's no reason I should be unable to set the fillMode on a CircleImage. This pull request simply exposes that property.