### PR TITLE
Fix issues on mobile/touch devices

### DIFF
--- a/modules/Material/Ink.qml
+++ b/modules/Material/Ink.qml
@@ -30,7 +30,7 @@ MouseArea {
     id: view
 
     clip: true
-    hoverEnabled: enabled
+    hoverEnabled: !Device.isMobile
     z: 2
 
     property int startRadius: circular ? width/10 : width/6


### PR DESCRIPTION
Touch devices do not interact very well with the "hover" property of the mouse area. This causes the widgets that use this object to get "stuck" with the color used when the item is clicked, even if the user is not touching/clicking the widget.

To fix this, we simply disable the hover feature when running on a mobile device.