### PR TITLE
Suppress meaningless error on ProgressCircle

### DIFF
--- a/modules/Material/ProgressCircle.qml
+++ b/modules/Material/ProgressCircle.qml
@@ -180,7 +180,7 @@ Controls.ProgressBar {
                     ctx.translate(canvas.width / 2, canvas.height / 2);
                     ctx.rotate(control.indeterminate ? internal.rotate : currentProgress * (3 * Math.PI / 2));
 
-                    ctx.arc(0, 0, Math.min(canvas.width, canvas.height) / 2 - ctx.lineWidth,
+                    ctx.arc(0, 0, Math.max(0, Math.min(canvas.width, canvas.height) / 2 - ctx.lineWidth),
                         control.indeterminate ? internal.arcStartPoint : 0,
                         control.indeterminate ? internal.arcEndPoint : currentProgress * (2 * Math.PI),
                         false);


### PR DESCRIPTION
In some cases where ProgressCircle's dimensions are set through property bindings, when the app is initially starting up and the bindings haven't resolved yet, the ProgressCircle's dimensions will be zero. This causes a negative radius when drawing the arc, which prints an error to the console. The behavior is not affected; once the bindings resolve and the ProgressCircle has non-zero dimensions, it works normally. Suppress this error by lower-bounding the radius to zero, as nothing has actually gone wrong.