### PR TITLE
Fixes qdoc strings

### DIFF
--- a/documentation/material.qdoc
+++ b/documentation/material.qdoc
@@ -1,5 +1,6 @@
 /*!
     \qmlmodule Material 0.1
     \title Material Design UI components
+    This implements Material Design for QtQuick.
 */
-This implements Material Design for QtQuick.
+

--- a/modules/Material/Action.qml
+++ b/modules/Material/Action.qml
@@ -19,7 +19,7 @@ import QtQuick 2.4
 import QtQuick.Controls 1.3 as Controls
 /*!
    \qmltype Action
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Represents an action shown in an action bar, context menu, or list.
 

--- a/modules/Material/ActionBar.qml
+++ b/modules/Material/ActionBar.qml
@@ -24,7 +24,7 @@ import Material.ListItems 0.1 as ListItem
 
 /*!
    \qmltype ActionBar
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief An action bar holds the title and actions displayed in the application toolbar.
 

--- a/modules/Material/ActionButton.qml
+++ b/modules/Material/ActionButton.qml
@@ -23,7 +23,7 @@ import QtGraphicalEffects 1.0
 
 /*!
    \qmltype ActionButton
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A floating action button.
 

--- a/modules/Material/AppTheme.qml
+++ b/modules/Material/AppTheme.qml
@@ -20,7 +20,7 @@ import Material 0.1
 
 /*!
    \qmltype AppTheme
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A helper class used in \l ApplicationWindow to set your app's theme colors.
  */

--- a/modules/Material/ApplicationWindow.qml
+++ b/modules/Material/ApplicationWindow.qml
@@ -23,7 +23,7 @@ import Material.Extras 0.1
 
 /*!
    \qmltype ApplicationWindow
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A window that provides features commonly used for Material Design apps.
 

--- a/modules/Material/AwesomeIcon.qml
+++ b/modules/Material/AwesomeIcon.qml
@@ -21,7 +21,7 @@ import 'awesome.js' as Awesome
 
 /*!
    \qmltype AwesomeIcon
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Displays an icon from the FontAwesome icon collection.
 

--- a/modules/Material/BottomActionSheet.qml
+++ b/modules/Material/BottomActionSheet.qml
@@ -21,7 +21,7 @@ import Material.ListItems 0.1 as ListItem
 
 /*!
    \qmltype BottomActionSheet
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Represents a bottom sheet displaying a list of actions with an optional title.
 

--- a/modules/Material/BottomSheet.qml
+++ b/modules/Material/BottomSheet.qml
@@ -21,7 +21,7 @@ import Material 0.1
 
 /*!
    \qmltype BottomSheet
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A bottom sheet is a sheet of paper that slides up from the bottom edge
    of the screen and presents a set of clear and simple actions.

--- a/modules/Material/Button.qml
+++ b/modules/Material/Button.qml
@@ -22,7 +22,7 @@ import Material 0.1
 
 /*!
    \qmltype Button
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A push button with a text label.
 

--- a/modules/Material/Card.qml
+++ b/modules/Material/Card.qml
@@ -20,7 +20,7 @@ import Material 0.1
 
 /*!
    \qmltype Card
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A card is a piece of paper with unique related data that serves as an entry point 
    to more detailed information.

--- a/modules/Material/CheckBox.qml
+++ b/modules/Material/CheckBox.qml
@@ -22,7 +22,7 @@ import Material 0.1
 
 /*!
    \qmltype CheckBox
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Checkboxes allow the user to select multiple options from a set.
  */

--- a/modules/Material/DatePicker.qml
+++ b/modules/Material/DatePicker.qml
@@ -26,7 +26,7 @@ import Material 0.1
 
 /*!
    \qmltype DatePicker
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Date Picker provides a simple way to select a valid, formatted date
  */

--- a/modules/Material/Device.qml
+++ b/modules/Material/Device.qml
@@ -21,7 +21,7 @@ pragma Singleton
 
 /*!
    \qmltype Device
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A singleton that provides information about the current device.
  */

--- a/modules/Material/Dialog.qml
+++ b/modules/Material/Dialog.qml
@@ -25,7 +25,7 @@ import Material.Extras 0.1
 
 /*!
    \qmltype Dialog
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
    \brief Dialogs inform users about critical information, require users to make
    decisions, or encapsulate multiple tasks within a discrete process
  */

--- a/modules/Material/Dropdown.qml
+++ b/modules/Material/Dropdown.qml
@@ -22,7 +22,7 @@ import Material.Extras 0.1
 
 /*!
    \qmltype Dropdown
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Represents a dropdown menu that can display a variety of content.
  */

--- a/modules/Material/Icon.qml
+++ b/modules/Material/Icon.qml
@@ -23,7 +23,7 @@ import QtGraphicalEffects 1.0
 
 /*!
    \qmltype Icon
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Displays an icon from the Material Design and FontAwesome icon collections.
 */

--- a/modules/Material/IconButton.qml
+++ b/modules/Material/IconButton.qml
@@ -21,7 +21,7 @@ import Material.Extras 0.1
 
 /*!
    \qmltype IconButton
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Icon buttons are appropriate for app bars, toolbars, action buttons or toggles.
  */

--- a/modules/Material/Ink.qml
+++ b/modules/Material/Ink.qml
@@ -22,7 +22,7 @@ import Material.Extras 0.1
 
 /*!
    \qmltype Ink
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Represents a ripple ink animation used in buttons and many other components.
  */

--- a/modules/Material/InputDialog.qml
+++ b/modules/Material/InputDialog.qml
@@ -20,7 +20,7 @@ import Material 0.1
 
 /*!
    \qmltype InputDialog
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A dialog with a single text field input.
  */

--- a/modules/Material/Label.qml
+++ b/modules/Material/Label.qml
@@ -20,7 +20,7 @@ import Material 0.1
 
 /*!
    \qmltype Label
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A text label with many different font styles from Material Design.
  */

--- a/modules/Material/ListItems/BaseListItem.qml
+++ b/modules/Material/ListItems/BaseListItem.qml
@@ -20,7 +20,7 @@ import ".."
 
 /*!
    \qmltype BaseListItem
-   \inqmlmodule Material.ListItems 0.1
+   \inqmlmodule Material.ListItems
 
    \brief The base class for list items.
 

--- a/modules/Material/ListItems/Divider.qml
+++ b/modules/Material/ListItems/Divider.qml
@@ -20,7 +20,7 @@ import Material 0.1
 
 /*!
    \qmltype Divider
-   \inqmlmodule Material.ListItems 0.1
+   \inqmlmodule Material.ListItems
 
    \brief A divider divides content in a list.
  */

--- a/modules/Material/ListItems/SectionHeader.qml
+++ b/modules/Material/ListItems/SectionHeader.qml
@@ -21,7 +21,7 @@ import Material 0.1
 
 /*!
    \qmltype SectionHeader
-   \inqmlmodule Material.ListItems 0.1
+   \inqmlmodule Material.ListItems
 
    \brief A list item that serves as the the header for an expandable list section.
  */

--- a/modules/Material/ListItems/SimpleMenu.qml
+++ b/modules/Material/ListItems/SimpleMenu.qml
@@ -21,7 +21,7 @@ import Material.Extras 0.1
 
 /*!
    \qmltype SimpleMenu
-   \inqmlmodule Material.ListItems 0.1
+   \inqmlmodule Material.ListItems
 
    \brief A list item that opens a dropdown menu when tapped.
  */

--- a/modules/Material/ListItems/Standard.qml
+++ b/modules/Material/ListItems/Standard.qml
@@ -22,7 +22,7 @@ import Material 0.1
 
 /*!
    \qmltype Standard
-   \inqmlmodule Material.ListItems 0.1
+   \inqmlmodule Material.ListItems
 
    \brief A simple list item with a single line of text and optional primary and secondary actions.
  */

--- a/modules/Material/ListItems/Subheader.qml
+++ b/modules/Material/ListItems/Subheader.qml
@@ -20,7 +20,7 @@ import Material 0.1
 
 /*!
    \qmltype Subheader
-   \inqmlmodule Material.ListItems 0.1
+   \inqmlmodule Material.ListItems
 
    \brief Subheaders are special list tiles that delineate distinct sections of a list or grid list.
  */

--- a/modules/Material/ListItems/Subtitled.qml
+++ b/modules/Material/ListItems/Subtitled.qml
@@ -22,7 +22,7 @@ import ".."
 
 /*!
    \qmltype Subtitled
-   \inqmlmodule Material.ListItems 0.1
+   \inqmlmodule Material.ListItems
 
    \brief A list item with a two or three lines of text and optional primary and secondary actions.
  */

--- a/modules/Material/MainView.qml
+++ b/modules/Material/MainView.qml
@@ -21,7 +21,7 @@ import Material 0.1
 
 /*!
    \qmltype MainView
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A root component with support for overlays and configuring the app theme.
  */

--- a/modules/Material/MaterialAnimation.qml
+++ b/modules/Material/MaterialAnimation.qml
@@ -21,7 +21,7 @@ pragma Singleton
 
 /*!
    \qmltype MaterialAnimation
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A singleton with common animation durations.
  */

--- a/modules/Material/MenuField.qml
+++ b/modules/Material/MenuField.qml
@@ -23,7 +23,7 @@ import Material.ListItems 0.1
 
 /*!
    \qmltype MenuField
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A input field similar to a text field but that opens a dropdown menu.
  */

--- a/modules/Material/NavigationDrawer.qml
+++ b/modules/Material/NavigationDrawer.qml
@@ -21,7 +21,7 @@ import Material 0.1
 
 /*!
    \qmltype NavigationDrawer
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief The navigation drawer slides in from the left and is a common pattern in apps.
  */

--- a/modules/Material/Object.qml
+++ b/modules/Material/Object.qml
@@ -19,7 +19,7 @@ import QtQuick 2.4
 
 /*!
    \qmltype Object
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A base class for non-visual objects.
  */

--- a/modules/Material/OverlayLayer.qml
+++ b/modules/Material/OverlayLayer.qml
@@ -19,7 +19,7 @@ import QtQuick 2.4
 
 /*!
    \qmltype OverlayLayer
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Provides a layer to display popups and other overlay components.
  */

--- a/modules/Material/OverlayView.qml
+++ b/modules/Material/OverlayView.qml
@@ -21,7 +21,7 @@ import Material.Extras 0.1
 
 /*!
    \qmltype OverlayView
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A view that pops out of the content to display as an overlay.
  */

--- a/modules/Material/Page.qml
+++ b/modules/Material/Page.qml
@@ -22,7 +22,7 @@ import Material 0.1
 
 /*!
    \qmltype Page
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Represents a page on the navigation page stack.
 

--- a/modules/Material/PageSidebar.qml
+++ b/modules/Material/PageSidebar.qml
@@ -21,7 +21,7 @@ import Material 0.1
 
 /*!
    \qmltype PageSidebar
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Represents a split sidebar in a page, with its own title, actions, and color 
    in the action bar.

--- a/modules/Material/PageStack.qml
+++ b/modules/Material/PageStack.qml
@@ -21,7 +21,7 @@ import Material 0.1
 
 /*!
    \qmltype PageStack
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Manages the page stack used for navigation.
 */

--- a/modules/Material/Palette.qml
+++ b/modules/Material/Palette.qml
@@ -22,7 +22,7 @@ pragma Singleton
 
 /*!
    \qmltype Palette
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Provides access to the Material Design color palette.
  */

--- a/modules/Material/Popover.qml
+++ b/modules/Material/Popover.qml
@@ -21,7 +21,7 @@ import Material.Extras 0.1
 
 /*!
    \qmltype Tooltip
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A tooltip is a label that appears on hover and explains a non-text UI element.
 

--- a/modules/Material/PopupBase.qml
+++ b/modules/Material/PopupBase.qml
@@ -22,7 +22,7 @@ import Material.Extras 0.1
 
 /*!
    \qmltype PopupBase
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A base class for popups such as dialogs or dropdowns.
  */

--- a/modules/Material/ProgressBar.qml
+++ b/modules/Material/ProgressBar.qml
@@ -23,7 +23,7 @@ import Material 0.1
 
 /*!
    \qmltype ProgressBar
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Visual indicator of progress in some operation.
 */

--- a/modules/Material/ProgressCircle.qml
+++ b/modules/Material/ProgressCircle.qml
@@ -23,7 +23,7 @@ import Material 0.1
 
 /*!
    \qmltype ProgressCircle
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Visual circular indicator of progress in some operation.
 */

--- a/modules/Material/RadioButton.qml
+++ b/modules/Material/RadioButton.qml
@@ -23,7 +23,7 @@ import Material 0.1
 
 /*!
    \qmltype RadioButton
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Radio buttons allow the user to select one option from a set.
 */

--- a/modules/Material/Scrollbar.qml
+++ b/modules/Material/Scrollbar.qml
@@ -19,7 +19,7 @@ import QtQuick 2.4
 
 /*!
    \qmltype Scrollbar
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Scrollbars show scrolling progress for listviews and flickables.
 */

--- a/modules/Material/Sidebar.qml
+++ b/modules/Material/Sidebar.qml
@@ -21,7 +21,7 @@ import "ListItems" as ListItem
 
 /*!
    \qmltype Sidebar
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A sidebar component for use in adaptive layouts
 

--- a/modules/Material/Slider.qml
+++ b/modules/Material/Slider.qml
@@ -23,7 +23,7 @@ import QtQuick.Controls.Styles.Material 0.1 as MaterialStyle
 
 /*!
    \qmltype Slider
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Sliders let users select a value from a continuous or discrete range of 
    values by moving the slider thumb.

--- a/modules/Material/Snackbar.qml
+++ b/modules/Material/Snackbar.qml
@@ -22,7 +22,7 @@ import Material 0.1
 
 /*!
    \qmltype Snackbar
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Snackbars provide lightweight feedback about an operation
  */

--- a/modules/Material/Switch.qml
+++ b/modules/Material/Switch.qml
@@ -23,7 +23,7 @@ import Material 0.1
 
 /*!
    \qmltype Switch
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief On/off switches toggle the state of a single settings option
  */

--- a/modules/Material/Tab.qml
+++ b/modules/Material/Tab.qml
@@ -20,7 +20,7 @@ import QtQuick.Controls 1.3 as Controls
 
 /*!
    \qmltype Tab
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Tab represents the content of a tab in a TabView.
 

--- a/modules/Material/TabbedPage.qml
+++ b/modules/Material/TabbedPage.qml
@@ -21,7 +21,7 @@ import QtQuick.Controls.Styles 1.3 as Styles
 
 /*!
    \qmltype Tab
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A special page for tabs.
 

--- a/modules/Material/TextField.qml
+++ b/modules/Material/TextField.qml
@@ -24,7 +24,7 @@ import Material 0.1
 
 /*!
    \qmltype TextField
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A single-line text input control.
  */

--- a/modules/Material/Theme.qml
+++ b/modules/Material/Theme.qml
@@ -21,7 +21,7 @@ pragma Singleton
 
 /*!
    \qmltype Theme
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Provides access to standard colors that follow the Material Design specification.
 

--- a/modules/Material/ThemePalette.qml
+++ b/modules/Material/ThemePalette.qml
@@ -19,7 +19,7 @@ import QtQuick 2.4
 
 /*!
    \qmltype Theme
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Provides access to standard colors that follow the Material Design specification, but
    specifically designed for light or dark surfaces.

--- a/modules/Material/ThinDivider.qml
+++ b/modules/Material/ThinDivider.qml
@@ -19,7 +19,7 @@ import QtQuick 2.4
 
 /*!
    \qmltype ThinDivider
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A 1dp high divider for use in lists and other columns of content.
  */

--- a/modules/Material/Toolbar.qml
+++ b/modules/Material/Toolbar.qml
@@ -23,7 +23,7 @@ import Material 0.1
 
 /*!
    \qmltype Toolbar
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Provides the container used to hold the action bar of pages.
 */

--- a/modules/Material/Tooltip.qml
+++ b/modules/Material/Tooltip.qml
@@ -22,7 +22,7 @@ import Material.Extras 0.1
 
 /*!
    \qmltype Tooltip
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A tooltip is a label that appears on hover and explains a non-text UI element.
 

--- a/modules/Material/Units.qml
+++ b/modules/Material/Units.qml
@@ -21,7 +21,7 @@ pragma Singleton
 
 /*!
    \qmltype Units
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Provides access to screen-independent Units known as DPs (device-independent pixels).
 

--- a/modules/Material/View.qml
+++ b/modules/Material/View.qml
@@ -21,7 +21,7 @@ import Material 0.1
 
 /*!
    \qmltype View
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Provides a base view component, with support for Material Design elevation, 
    background colors, and tinting.

--- a/modules/Material/Wave.qml
+++ b/modules/Material/Wave.qml
@@ -20,7 +20,7 @@ import QtQuick 2.4
 
 /*!
    \qmltype Wave
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief Provides a wave animation for transitioning between views of content.
  */

--- a/modules/Material/Window.qml
+++ b/modules/Material/Window.qml
@@ -21,7 +21,7 @@ import QtQuick.Window 2.2
 
 /*!
    \qmltype Window
-   \inqmlmodule Material 0.1
+   \inqmlmodule Material
 
    \brief A subclass of QtQuick.Window that provides some additional features for developing Applications
    that conform to Material Design.


### PR DESCRIPTION
Just a minor fix. Changes:
* Put the description in `material.qdoc` into comments
* Changed `\inqmlmodule Material 0.1` and `\inqmlmodule Material.ListItems 0.1` to `\inqmlmodule Material` and `\inqmlmodule Material.ListItems` (as there should be no version number according to the [docs](http://doc.qt.io/qt-5/13-qdoc-commands-topics.html#inqmlmodule-command))