### PR TITLE
Remove the import of Material in Palette.qml to fix recursive import.

### DIFF
--- a/modules/Material/Palette.qml
+++ b/modules/Material/Palette.qml
@@ -16,7 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import QtQuick 2.4
-import Material 0.2
 
 pragma Singleton
 


### PR DESCRIPTION
Importing `Material` in Palette.qml does not seems to be necessary, and breaks
when including `qml-material` as C++/Qt compiled resources.

This should fix issue #372.
