### PR TITLE
Expose more ActionButton properties

### DIFF
--- a/modules/Material/ActionButton.qml
+++ b/modules/Material/ActionButton.qml
@@ -67,6 +67,11 @@ Controls.Button {
     property int iconSize: Units.dp(24)
 
     /*!
+       The rotation of the icon (in degrees).
+     */
+    property int iconRotation: 0
+
+    /*!
        Floating action buttons come in two sizes:
 
        \list
@@ -136,6 +141,7 @@ Controls.Button {
                 name: control.iconName
                 color: button.iconColor
                 size: iconSize
+                rotation: iconRotation
             }
         }
     }

--- a/modules/Material/ActionButton.qml
+++ b/modules/Material/ActionButton.qml
@@ -62,6 +62,11 @@ Controls.Button {
     property string iconName: action ? action.iconName : ""
 
     /*!
+       The size of the icon.
+     */
+    property int iconSize: Units.dp(24)
+
+    /*!
        Floating action buttons come in two sizes:
 
        \list
@@ -130,7 +135,7 @@ Controls.Button {
                 anchors.centerIn: parent
                 name: control.iconName
                 color: button.iconColor
-                size: Units.dp(24)
+                size: iconSize
             }
         }
     }


### PR DESCRIPTION
For my project I need to be able to set the `ActionButton`'s icon size and rotation. This PR exposes these two properties so they can be changed, using the same defaults as was there previously.
