### PR TITLE
Fix issue #382.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,11 @@ include(KDECMakeSettings)
 include(KDECompilerSettings)
 include(FeatureSummary)
 
+# Set cmake policy for hiding inlines
+# We just use these for compiling tests, so it doesn't really
+# effect us, but this removes the error
+cmake_policy(SET CMP0063 NEW)
+
 # Build flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden -Werror -Wall -Wextra -Wno-unused-parameter -pedantic -std=c++11")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ include(FeatureSummary)
 # Set cmake policy for hiding inlines
 # We just use these for compiling tests, so it doesn't really
 # effect us, but this removes the error
-cmake_policy(SET CMP0063 NEW)
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
 
 # Build flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden -Werror -Wall -Wextra -Wno-unused-parameter -pedantic -std=c++11")


### PR DESCRIPTION
CMake is warning users about using the old policy for hiding inlined
functions. This doesn't really effect us due to the fact that we don't
ship any executables other than tests.
