### PR TITLE
Right multiplier for Android platform +Fixed  extra ressource file +Fixed .pri missing setting

### DIFF
--- a/material.pri
+++ b/material.pri
@@ -1,5 +1,9 @@
 QT += qml quick
 
+android {
+	QT += androidextras
+}
+
 HEADERS += $$PWD/src/plugin.h \
            $$PWD/src/core/device.h \
            $$PWD/src/core/units.h

--- a/src/core/units.cpp
+++ b/src/core/units.cpp
@@ -127,6 +127,7 @@ void UnitsAttached::updateDPI()
         return;
     }
     m_dpi = displayMetrics.getField<int>("densityDpi");
+    m_multiplier = displayMetrics.getField<float>("density");
 #else
     // standard dpi
     m_dpi = m_screen->logicalDotsPerInch() * m_screen->devicePixelRatio();

--- a/src/extras/extras.qrc
+++ b/src/extras/extras.qrc
@@ -1,14 +1,13 @@
-<!DOCTYPE RCC>
-<RCC version="1.0">
-
-<qresource prefix="/Material/Extras">
-	<file>AutomaticGrid.qml</file>
-	<file>CircleImage.qml</file>
-	<file>CircleMask.qml</file>
-	<file>ColumnFlow.qml</file>
-	<file>Image.qml</file>
-	<file>circle.png</file>
-	<file>qmldir</file>
-</qresource>
-
+<RCC>
+    <qresource prefix="/Material/Extras">
+        <file>AutomaticGrid.qml</file>
+        <file>CircleImage.qml</file>
+        <file>CircleMask.qml</file>
+        <file>ColumnFlow.qml</file>
+        <file>Image.qml</file>
+        <file>qmldir</file>
+    </qresource>
+    <qresource prefix="/Material/Extras/images">
+        <file>circle.png</file>
+    </qresource>
 </RCC>


### PR DESCRIPTION
- Extra resources qrc was missing a prefix part to retrieve the circle.png  image on CircularImage.
- .pri file (needed for qpm package ), the androidextra was missing in QT var.
- multiplier was never set for Android, resulting in unscaled UI.
