### PR TITLE
Progress on #409 - Document required registration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ To optionally bundle the Roboto fonts in your project, add this line **ABOVE** t
 
     OPTIONS += roboto
 
+Then you'll need to register qml-material. In your `main.cpp` or similar,
+
+    #include "material/src/plugin.h"
+
+    // ... your code ...
+
+    engine.addImportPath(":/."); // engine is your QQMLEngine
+    MaterialPlugin qmlMaterial;
+    qmlMaterial.registerTypes("Material");
+
+You should then be able to `import Material 0.3` from your QML.
+
 ### System-wide installation
 
 From the root of the repository, run:


### PR DESCRIPTION
From what I understand after discussion with @voidware and @tswindell, these steps are required if you don't go the global-install way.

If correct, this should fix point 1. of #409. I'm still unsure about point 2. (how to un-confuse QtCreator).
