### PR TITLE
Expose Icon.colorize property in ListItem.Standard

### DIFF
--- a/demo/icons/navigation_menu.svg
+++ b/demo/icons/navigation_menu.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"><path d="M6 36h36v-4H6v4zm0-10h36v-4H6v4zm0-14v4h36v-4H6z"/></svg>

--- a/src/listitems/Standard.qml
+++ b/src/listitems/Standard.qml
@@ -39,6 +39,7 @@ BaseListItem {
 
     property alias textColor: label.color
     property alias iconColor: icon.color
+    property alias colorizeIcon: icon.colorize
 
     dividerInset: actionItem.visible ? listItem.height : 0
 


### PR DESCRIPTION
## Brief:

This is a very simple addition to help development of the papyros/files-app.
It allows a user to choose whether the icon on a `ListItem.Standard`
is colorized or not. In a `ListItem.Standard` a user can now use the
property `colorizeIcon:` which takes a bool and is an alias for `icon.colorize` in the
`ListItem.Standard`.

This came to be an issue when attempting to list mimetype icons
in the papyros files app as they were all using a `ColorOverlay` instead
of an image.
## Changes:

```
1. Added a `colorizeIcon:` property in `ListItem.Standard`
   which allows a user to turn the `ColorOverlay` on and
   off at will.
```
## Data:
### Here's what I get when I have no control over `icon.colorize`

![before_colorize](https://cloud.githubusercontent.com/assets/6127137/14519896/cf4d3126-01de-11e6-8ebb-792814a94888.png)
<br>
###### As you can see the icons (test icons) that I need to be shown as images are shown with an overlay

<br>
### The results of `colorizeIcon: false`

![after_colorize](https://cloud.githubusercontent.com/assets/6127137/14520021/70f61664-01df-11e6-86f3-c7b3a7fd9053.png)
<br>
###### Now the test icons show up and I can begin implementing the mimetype logic

<br>
### Here's what the `colorizeIcon:` property looks like when used

![colorizecode](https://cloud.githubusercontent.com/assets/6127137/14519977/34a92d72-01df-11e6-8c86-592169559d76.png)

<br>
###### Line 31: How `colorizeIcon:` would be used.

<br>

I know that the files-app is using an earlier version of qml-material than what's on develop but it would still be a useful property and would give incentive to migrate the files app to a newer version of qml-material when the time comes
