### PR TITLE
Qmlmat 1 enable switch insert in action bar

### DIFF
--- a/demo/demo.qrc
+++ b/demo/demo.qrc
@@ -35,8 +35,7 @@
 	<file>icons/file_file_download.svg</file>
 	<file>icons/image_color_lens.svg</file>
 	<file>icons/maps_place.svg</file>
-	<file>icons/navigation_arrow_drop_down.svg</file>
-	<file>icons/navigation_menu.svg</file>
+        <file>icons/navigation_arrow_drop_down.svg</file>
 	<file>icons/social_share.svg</file>
 	<file>images/balloon.jpg</file>
 	<file>images/go-last.color.svg</file>

--- a/src/controls/Action.qml
+++ b/src/controls/Action.qml
@@ -29,6 +29,11 @@ Controls.Action {
     property bool hasDividerAfter
 
     /*!
+      used to display the action as switch control on the ActionBar
+      */
+    property bool displayAsSwitch: false
+
+    /*!
        A URL pointing to an image to display as the icon. By default, this is
        a special URL representing the icon named by \l iconName from the Material Design
        icon collection or FontAwesome. The icon will be colorized using the specificed \l color,
@@ -63,4 +68,8 @@ Controls.Action {
 
     property alias text: action.name
     property alias tooltip: action.summary
+
+    onDisplayAsSwitchChanged: {
+        if(displayAsSwitch == true)checkable = true
+    }
 }

--- a/src/controls/Switch.qml
+++ b/src/controls/Switch.qml
@@ -28,12 +28,6 @@ Controls.Switch {
       */
     property Action action
 
-    onCheckedChanged: {
-        if(action !== null){
-            action.checked = checked
-            action.toggled(checked)
-        }
-    }
 
     /*!
        The switch color. By default this is the app's accent color
@@ -80,6 +74,13 @@ Controls.Switch {
                     }
                 }
             }
+        }
+    }
+
+    onCheckedChanged: {
+        if(action !== null){
+            action.checked = checked
+            action.toggled(checked)
         }
     }
 }

--- a/src/controls/Switch.qml
+++ b/src/controls/Switch.qml
@@ -23,6 +23,15 @@ import Material 0.3
 Controls.Switch {
     id: control
 
+    property Action action
+
+    onCheckedChanged: {
+        if(action !== null){
+            action.checked = checked
+            action.toggled(checked)
+        }
+    }
+
     /*!
        The switch color. By default this is the app's accent color
      */
@@ -43,8 +52,8 @@ Controls.Switch {
             backgroundColor: control.enabled ? control.checked ? control.color
                                                                : darkBackground ? "#BDBDBD"
                                                                                 : "#FAFAFA"
-                                             : darkBackground ? "#424242"
-                                                              : "#BDBDBD"
+            : darkBackground ? "#424242"
+            : "#BDBDBD"
         }
 
         groove: Item {
@@ -59,8 +68,8 @@ Controls.Switch {
                 color: control.enabled ? control.checked ? Theme.alpha(control.color, 0.5)
                                                          : darkBackground ? Qt.rgba(1, 1, 1, 0.26)
                                                                           : Qt.rgba(0, 0, 0, 0.26)
-                                       : darkBackground ? Qt.rgba(1, 1, 1, 0.12)
-                                                        : Qt.rgba(0, 0, 0, 0.12)
+                : darkBackground ? Qt.rgba(1, 1, 1, 0.12)
+                : Qt.rgba(0, 0, 0, 0.12)
 
                 Behavior on color {
                     ColorAnimation {

--- a/src/controls/Switch.qml
+++ b/src/controls/Switch.qml
@@ -23,6 +23,9 @@ import Material 0.3
 Controls.Switch {
     id: control
 
+    /*!
+      This action can be used when integrating switch to actionBar
+      */
     property Action action
 
     onCheckedChanged: {

--- a/src/window/ActionBar.qml
+++ b/src/window/ActionBar.qml
@@ -176,6 +176,30 @@ Item {
     property int leftKeyline: label.x
 
     /*!
+      The switch Component if displayAsSwitch is used for actions
+      */
+
+    property Component switchDelegate : Component{
+        Switch{
+        }
+    }
+
+    /*!
+      the iconButton component used for actions
+      */
+    property Component iconButtonDelegate: Component{
+        IconButton {
+
+            color: Theme.lightDark(actionBar.backgroundColor, Theme.light.iconColor,
+                                   Theme.dark.iconColor)
+            size: actionBar.iconSize
+
+            anchors.verticalCenter: parent ? parent.verticalCenter : undefined
+
+        }
+    }
+
+    /*!
        \internal
        \qmlproperty bool overflowMenuShowing
 
@@ -285,65 +309,52 @@ Item {
         spacing: 24 * Units.dp
 
         Repeater {
+            id : actionsRepeater
+
+            function  updateActions() {
+                for(var i=0; i < count;i++){
+
+                    if(itemAt(i).item.action !==  __internal.visibleActions[i])
+                        itemAt(i).item.action =  __internal.visibleActions[i]
+
+                    if(itemAt(i).item.objectName !== "action/" + itemAt(i).item.action.objectName)
+                        itemAt(i).item.objectName = "action/" + itemAt(i).item.action.objectName
+                }
+            }
+
             model: __internal.visibleActions.length > maxActionCount
                    ? maxActionCount - 1
                    : __internal.visibleActions.length
 
-
-            delegate:Loader{
-                width:iconSize
-                height: iconSize
+            delegate :Loader{
+                // content is resized to the loaded item size
                 anchors.verticalCenter: parent ? parent.verticalCenter : undefined
-                sourceComponent: __internal.visibleActions[index].displayAsSwitch?switchDelegate:iconAction
-
-
-                Component{
-                    id:switchDelegate
-                    Switch{
-                        width: iconSize*2.5
-                        height: iconSize
-                        action: __internal.visibleActions[index]
-                        anchors{
-                            rightMargin: 15
-                            leftMargin: 15
-                        }
-                    }
-
-                }
-
-                Component{
-                    id: iconAction
-                    IconButton {
-
-                        objectName: "action/" + action.objectName
-
-                        action: __internal.visibleActions[index]
-
-                        color: Theme.lightDark(actionBar.backgroundColor, Theme.light.iconColor,
-                                               Theme.dark.iconColor)
-                        size: iconSize
-
-                        anchors.verticalCenter: parent ? parent.verticalCenter : undefined
-                    }
-                }
+                sourceComponent: __internal.visibleActions[index].displayAsSwitch?
+                                     switchDelegate:iconButtonDelegate
             }
 
-
+            Component.onCompleted: {
+                // first time setting repeater's actions
+                updateActions()
+                // bind the model changes to updating actions
+                modelChanged.connect(function(){updateActions()})
+            }
         }
+    }
 
-        IconButton {
-            id: overflowButton
 
-            iconName: "navigation/more_vert"
-            objectName: "action/overflow"
-            size: 27 * Units.dp
-            color: Theme.lightDark(actionBar.backgroundColor, Theme.light.iconColor,
-                                   Theme.dark.iconColor)
-            visible: actionBar.overflowMenuAvailable
-            anchors.verticalCenter: parent.verticalCenter
+    IconButton {
+        id: overflowButton
 
-            onClicked: openOverflowMenu()
-        }
+        iconName: "navigation/more_vert"
+        objectName: "action/overflow"
+        size: 27 * Units.dp
+        color: Theme.lightDark(actionBar.backgroundColor, Theme.light.iconColor,
+                               Theme.dark.iconColor)
+        visible: actionBar.overflowMenuAvailable
+        anchors.verticalCenter: parent.verticalCenter
+
+        onClicked: openOverflowMenu()
     }
 
     Item {
@@ -419,3 +430,4 @@ Item {
         }
     }
 }
+

--- a/src/window/ActionBar.qml
+++ b/src/window/ActionBar.qml
@@ -294,7 +294,7 @@ Item {
                 width:iconSize
                 height: iconSize
                 anchors.verticalCenter: parent ? parent.verticalCenter : undefined
-                sourceComponent: __internal.visibleActions[index].checkable?switchDelegate:iconAction
+                sourceComponent: __internal.visibleActions[index].displayAsSwitch?switchDelegate:iconAction
 
 
                 Component{

--- a/src/window/ActionBar.qml
+++ b/src/window/ActionBar.qml
@@ -99,7 +99,7 @@ Item {
        The height of the extended content view.
      */
     readonly property int extendedHeight: extendedContentView.height +
-            (tabBar.visible && !integratedTabBar ? tabBar.height : 0)
+                                          (tabBar.visible && !integratedTabBar ? tabBar.height : 0)
 
     /*!
        Set to true to hide the action bar. This is used when displaying an
@@ -232,7 +232,7 @@ Item {
         }
 
         color: Theme.lightDark(actionBar.backgroundColor, Theme.light.iconColor,
-                                                            Theme.dark.iconColor)
+                               Theme.dark.iconColor)
         size: iconSize
         action: backAction
 
@@ -262,13 +262,13 @@ Item {
         }
 
         visible: customContentView.children.length === 0 &&
-                (!integratedTabBar || !tabBar.visible)
+                 (!integratedTabBar || !tabBar.visible)
 
         textFormat: Text.PlainText
         text: actionBar.title
         style: "title"
         color: Theme.lightDark(actionBar.backgroundColor, Theme.light.textColor,
-                                                            Theme.dark.textColor)
+                               Theme.dark.textColor)
         elide: Text.ElideRight
     }
 
@@ -286,22 +286,49 @@ Item {
 
         Repeater {
             model: __internal.visibleActions.length > maxActionCount
-                    ? maxActionCount - 1
-                    : __internal.visibleActions.length
+                   ? maxActionCount - 1
+                   : __internal.visibleActions.length
 
-            delegate: IconButton {
-                id: iconAction
 
-                objectName: "action/" + action.objectName
-
-                action: __internal.visibleActions[index]
-
-                color: Theme.lightDark(actionBar.backgroundColor, Theme.light.iconColor,
-                                                                  Theme.dark.iconColor)
-                size: iconSize
-
+            delegate:Loader{
+                width:iconSize
+                height: iconSize
                 anchors.verticalCenter: parent ? parent.verticalCenter : undefined
+                sourceComponent: __internal.visibleActions[index].checkable?switchDelegate:iconAction
+
+
+                Component{
+                    id:switchDelegate
+                    Switch{
+                        width: iconSize*2.5
+                        height: iconSize
+                        action: __internal.visibleActions[index]
+                        anchors{
+                            rightMargin: 15
+                            leftMargin: 15
+                        }
+                    }
+
+                }
+
+                Component{
+                    id: iconAction
+                    IconButton {
+
+                        objectName: "action/" + action.objectName
+
+                        action: __internal.visibleActions[index]
+
+                        color: Theme.lightDark(actionBar.backgroundColor, Theme.light.iconColor,
+                                               Theme.dark.iconColor)
+                        size: iconSize
+
+                        anchors.verticalCenter: parent ? parent.verticalCenter : undefined
+                    }
+                }
             }
+
+
         }
 
         IconButton {
@@ -311,7 +338,7 @@ Item {
             objectName: "action/overflow"
             size: 27 * Units.dp
             color: Theme.lightDark(actionBar.backgroundColor, Theme.light.iconColor,
-                                                              Theme.dark.iconColor)
+                                   Theme.dark.iconColor)
             visible: actionBar.overflowMenuAvailable
             anchors.verticalCenter: parent.verticalCenter
 


### PR DESCRIPTION
Allowing to have switches as actions in the action-bar. 
- Exposing elements used in the actionBar (Switches and IconButtons) as properties of the ActionBar, so that is possible to provide custom styles if needed.
- possible fix for the [issue#406](https://github.com/papyros/qml-material/issues/406)

Ok for having this contribution licensed as MPL
