### PR TITLE
add iconhelper plugin to support icons both in system-wide installati…

### DIFF
--- a/demo/demo.pro
+++ b/demo/demo.pro
@@ -2,5 +2,10 @@ TEMPLATE = app
 
 QT += qml quick
 
+DEFINES += QPM_INIT
+OPTIONS += roboto
+
+include(../material.pri)
+
 SOURCES += main.cpp
 RESOURCES += demo.qrc icons/icons.qrc

--- a/demo/demo.qrc
+++ b/demo/demo.qrc
@@ -21,7 +21,7 @@
 	<file>TextFieldDemo.qml</file>
 	<file>TimePickerDemo.qml</file>
 	<file>TypographyDemo.qml</file>
-	<file>icons/action_account_circle.svg</file>
+        <!--<file>icons/action_account_circle.svg</file>
 	<file>icons/action_autorenew.svg</file>
 	<file>icons/action_delete.svg</file>
 	<file>icons/action_language.svg</file>
@@ -37,7 +37,7 @@
 	<file>icons/maps_place.svg</file>
 	<file>icons/navigation_arrow_drop_down.svg</file>
 	<file>icons/navigation_menu.svg</file>
-	<file>icons/social_share.svg</file>
+        <file>icons/social_share.svg</file>-->
 	<file>images/balloon.jpg</file>
 	<file>images/go-last.color.svg</file>
 	<file>images/list-add.color.svg</file>

--- a/demo/icons/icons.qrc
+++ b/demo/icons/icons.qrc
@@ -1,42 +1,42 @@
 <!DOCTYPE RCC>
 <RCC version="1.0">
 
-<qresource prefix="/icons/maps">
+<qresource prefix="/demoicons/maps">
 	<file alias="place.svg">maps_place.svg</file>
 </qresource>
 
-<qresource prefix="/icons/communication">
+<qresource prefix="/demoicons/communication">
 	<file alias="email.svg">communication_email.svg</file>
 </qresource>
 
-<qresource prefix="/icons/image">
+<qresource prefix="/demoicons/image">
 	<file alias="color_lens.svg">image_color_lens.svg</file>
 	<file alias="edit.svg">image_edit.svg</file>
 </qresource>
 
-<qresource prefix="/icons/alert">
+<qresource prefix="/demoicons/alert">
 	<file alias="warning.svg">alert_warning.svg</file>
 </qresource>
 
-<qresource prefix="/icons/content">
+<qresource prefix="/demoicons/content">
 	<file alias="add.svg">content_add.svg</file>
 	<file alias="create.svg">content_create.svg</file>
 	<file alias="forward.svg">content_forward.svg</file>
 </qresource>
 
-<qresource prefix="/icons/device">
+<qresource prefix="/demoicons/device">
 	<file alias="access_alarm.svg">device_access_alarm.svg</file>
 </qresource>
 
-<qresource prefix="/icons/file">
+<qresource prefix="/demoicons/file">
 	<file alias="file_download.svg">file_file_download.svg</file>
 </qresource>
 
-<qresource prefix="/icons/social">
+<qresource prefix="/demoicons/social">
 	<file alias="share.svg">social_share.svg</file>
 </qresource>
 
-<qresource prefix="/icons/action">
+<qresource prefix="/demoicons/action">
 	<file alias="account_circle.svg">action_account_circle.svg</file>
 	<file alias="autorenew.svg">action_autorenew.svg</file>
 	<file alias="delete.svg">action_delete.svg</file>
@@ -44,7 +44,7 @@
 	<file alias="settings.svg">action_settings.svg</file>
 </qresource>
 
-<qresource prefix="/icons/navigation">
+<qresource prefix="/demoicons/navigation">
 	<file alias="arrow_drop_down.svg">navigation_arrow_drop_down.svg</file>
 </qresource>
 

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -5,7 +5,9 @@ int main(int argc, char *argv[])
 {
     QGuiApplication app(argc, argv);
 
-    QQmlApplicationEngine engine(QUrl(QStringLiteral("qrc:/main.qml")));
+    QQmlApplicationEngine engine;
+    engine.addImportPath("qrc:///");
+    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
 
     return app.exec();
 }

--- a/demo/main.qml
+++ b/demo/main.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.4
-import Material 0.2
+import Material 0.3
 import Material.ListItems 0.1 as ListItem
 
 ApplicationWindow {

--- a/demo/main.qml
+++ b/demo/main.qml
@@ -16,6 +16,17 @@ ApplicationWindow {
         tabHighlightColor: "white"
     }
 
+    iconHelper {
+        useQtResource: true
+        /**************************
+        if set useQtResource to true, alternativePath should be the prefix value in qrc
+        if set useQtResource to false
+            if using material system-wide icons, alternativePath should be setted to empty, Eg. ""
+            if using application alternative icons, alternativePath should be setted to full path of icon path
+        ***************************/
+        alternativePath: "demoicons"
+    }
+
     property var styles: [
             "Custom Icons", "Color Palette", "Typography"
     ]

--- a/material.pri
+++ b/material.pri
@@ -7,11 +7,13 @@ android {
 
 HEADERS += $$PWD/src/plugin.h \
            $$PWD/src/core/device.h \
-           $$PWD/src/core/units.h
+           $$PWD/src/core/units.h \
+           $$PWD/src/core/iconhelper.h
 
 SOURCES += $$PWD/src/plugin.cpp \
            $$PWD/src/core/device.cpp \
-           $$PWD/src/core/units.cpp
+           $$PWD/src/core/units.cpp \
+           $$PWD/src/core/iconhelper.cpp
 
 RESOURCES += $$PWD/src/material.qrc \
              $$PWD/src/components/components.qrc \

--- a/src/core/Icon.qml
+++ b/src/core/Icon.qml
@@ -64,7 +64,7 @@ Item {
                 var name = icon.source.substring(7)
 
                 if (name)
-                    return "qrc:/icons/" + name + '.svg'
+                    return iconHelper.parseIcon(name) + '.svg' //"qrc:/icons/" + name + '.svg'
                 else
                     return ""
             } else {

--- a/src/core/iconhelper.cpp
+++ b/src/core/iconhelper.cpp
@@ -1,0 +1,78 @@
+#include "iconhelper.h"
+
+#include <QCoreApplication>
+#include <QDebug>
+#include <QDir>
+
+#include <QQmlEngine>
+#include <QJSEngine>
+
+IconHelper::IconHelper(QObject *parent)
+    : QObject(parent)
+    , m_useQtResource(false)
+    , m_alternativePath(QString())
+    , m_applicationPath(qApp->applicationDirPath())
+{
+#ifdef MATERIAL_ICON_PATH
+    m_libraryPath = QString(MATERIAL_ICON_PATH);
+#else
+    qWarning()<<Q_FUNC_INFO<<"can't find system-wide installation qml-material library path";
+    m_libraryPath = QString();
+#endif
+}
+
+IconHelper::~IconHelper()
+{
+
+}
+
+QString IconHelper::parseIcon(const QString &icon)
+{
+    if (icon.isEmpty())
+        return QString();
+    if (m_useQtResource) {
+        if (!m_alternativePath.isEmpty()) {
+            QString tmp = m_alternativePath.toLower();
+            if (tmp != m_alternativePath)
+                qWarning()<<Q_FUNC_INFO<<"alternativePath should be lower case characters";
+            return QString("qrc:/%1/%2").arg(m_alternativePath).arg(icon);
+        } else {
+            return QString("qrc:/icons/%1").arg(icon);
+        }
+    } else {
+        if (!m_alternativePath.isEmpty()) {
+            return QString("%1/%2").arg(m_alternativePath).arg(icon);
+        } else {
+            return QString("%1/%2").arg(m_libraryPath).arg(icon);
+        }
+    }
+}
+
+bool IconHelper::useQtResource() const
+{
+    return m_useQtResource;
+}
+
+QString IconHelper::alternativePath() const
+{
+    return m_alternativePath;
+}
+
+QString IconHelper::applicationPath() const
+{
+    return m_applicationPath;
+}
+
+void IconHelper::setUseQtResource(bool useQtResource)
+{
+    m_useQtResource = useQtResource;
+}
+
+void IconHelper::setAlternativePath(QString alternativePath)
+{
+    m_alternativePath = alternativePath;
+    QDir dir(m_alternativePath);
+    if (!dir.exists())
+        qDebug()<<Q_FUNC_INFO<<QString("Can't find icon path [%1], alternativePath should be full application path").arg(m_alternativePath);
+
+}

--- a/src/core/iconhelper.h
+++ b/src/core/iconhelper.h
@@ -1,0 +1,43 @@
+#ifndef ICONHELPER_H
+#define ICONHELPER_H
+
+#include <QObject>
+
+class QQmlEngine;
+class QJSEngine;
+class IconHelper : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool useQtResource READ useQtResource WRITE setUseQtResource)
+    Q_PROPERTY(QString alternativePath READ alternativePath WRITE setAlternativePath)
+    Q_PROPERTY(QString applicationPath READ applicationPath CONSTANT)
+
+public:
+    explicit IconHelper(QObject *parent = 0);
+    virtual ~IconHelper();
+
+    ///
+    /// \brief parseIcon
+    /// \param icon the iconname
+    /// \return
+    ///
+    Q_INVOKABLE QString parseIcon(const QString &icon);
+
+    bool useQtResource() const;
+    QString alternativePath() const;
+    QString applicationPath() const;
+
+public slots:
+    void setUseQtResource(bool useQtResource);
+    void setAlternativePath(QString alternativePath);
+
+private:
+    bool m_useQtResource;
+    QString m_alternativePath;
+    QString m_applicationPath;
+    QString m_libraryPath;
+};
+
+
+#endif // ICONHELPER_H

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -14,12 +14,14 @@
 
 #include "core/device.h"
 #include "core/units.h"
+#include "core/iconhelper.h"
 
 class MaterialRegisterHelper {
 
 public:
     MaterialRegisterHelper(const char *uri) {
         qmlRegisterSingletonType<Device>(uri, 0, 1, "Device", Device::qmlSingleton);
+        qmlRegisterType<IconHelper>(uri, 0, 1, "IconHelper"/*, IconHelper::qmlSingleton*/);
         qmlRegisterUncreatableType<Units>(uri, 0, 3, "Units", QStringLiteral("Units can only be used via the attached property."));
     }
 };

--- a/src/src.pro
+++ b/src/src.pro
@@ -4,6 +4,7 @@ TARGET = material
 CONFIG += c++11
 QT += qml quick
 
+DEFINES += MATERIAL_ICON_PATH=\\\"$$[QT_INSTALL_QML]/Material/icons\\\"
 
 android {
     QT += androidextras svg xml
@@ -11,13 +12,15 @@ android {
 
 HEADERS += plugin.h \
            core/device.h \
-           core/units.h
+           core/units.h \
+           core/iconhelper.h
 
 SOURCES += plugin.cpp \
            core/device.cpp \
-           core/units.cpp
+           core/units.cpp \
+           core/iconhelper.cpp
 
-RESOURCES += ../icons/core_icons.qrc
+#RESOURCES += ../icons/core_icons.qrc
 
 target.path = $$[QT_INSTALL_QML]/Material
 

--- a/src/window/ApplicationWindow.qml
+++ b/src/window/ApplicationWindow.qml
@@ -77,6 +77,26 @@ Controls.ApplicationWindow {
      */
     property alias theme: __theme
 
+    /*!
+       \qmlproperty IconHelper iconHelper
+
+       IconHelper is a c++ plugin that allows the application to use material icons wether in qrc or
+       in local-filesystem.
+     */
+    property alias iconHelper: __iconHelperPriv
+
+    IconHelper {
+        id: __iconHelperPriv
+        /**************************
+        if set useQtResource to true, alternativePath should be the prefix value in qrc
+        if set useQtResource to false
+            if using material system-wide icons, alternativePath should be setted to empty, Eg. ""
+            if using application alternative icons, alternativePath should be setted to full path of icon path
+        ***************************/
+        useQtResource: false
+        alternativePath: ""
+    }
+
     AppTheme {
         id: __theme
     }


### PR DESCRIPTION
If material icons are installed in system-wide, eg. library_path/to/qml/Material/icons, it could be loaded from local-filesystem or qrc.
If devs want to use their own icons, they can set IconHelper property to use from both qrc or application file-system.
