### PR TITLE
Fixes problems with the demo and an annoying warning

### DIFF
--- a/demo/demo.pro
+++ b/demo/demo.pro
@@ -4,3 +4,8 @@ QT += qml quick
 
 SOURCES += main.cpp
 RESOURCES += demo.qrc icons/icons.qrc
+
+# Include qml-material
+OPTIONS += roboto
+DEFINES += QPM_INIT
+include(../material.pri)

--- a/demo/icons/navigation_menu.svg
+++ b/demo/icons/navigation_menu.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48"><path d="M6 36h36v-4H6v4zm0-10h36v-4H6v4zm0-14v4h36v-4H6z"/></svg>

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -5,7 +5,9 @@ int main(int argc, char *argv[])
 {
     QGuiApplication app(argc, argv);
 
-    QQmlApplicationEngine engine(QUrl(QStringLiteral("qrc:/main.qml")));
+    QQmlApplicationEngine engine;
+    engine.addImportPath( "qrc:///" );
+    engine.load( QUrl( QStringLiteral( "qrc:/main.qml" ) ) );
 
     return app.exec();
 }

--- a/src/core/units.cpp
+++ b/src/core/units.cpp
@@ -20,7 +20,7 @@
 #define DEFAULT_DPI 72
 
 UnitsAttached::UnitsAttached(QObject *attachee)
-        : QObject(attachee), m_screen(nullptr), m_window(nullptr), m_multiplier(1), m_dpi(0)
+        : QObject(attachee), m_screen(nullptr), m_window(nullptr), m_dpi(0), m_multiplier(1)
 {
     m_attachee = qobject_cast<QQuickItem *>(attachee);
 


### PR DESCRIPTION
``` cpp
warning: field 'm_multiplier' will be initialized after field 'm_dpi'
[-Wreorder]
: QObject(attachee), m_screen(nullptr), m_window(nullptr),
m_multiplier(1), m_dpi(0)
```
