### PR TITLE
Added default switch case to Device::iconName()

### DIFF
--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -83,6 +83,7 @@ QString Device::iconName() const
         case TV:
             return "hardware/tv";
         case Unknown:
+        default:
             return "hardware/computer";
     }
 }


### PR DESCRIPTION
Added a Default case to the function iconName in Device.cpp to remove an unnecessary warning:

> > [...]/material/src/core/device.cpp:89: warning: control reaches end of non-void function [-Wreturn-type]
