### PR TITLE
Fixing Theme.light.textColor

### DIFF
--- a/src/core/ThemePalette.qml
+++ b/src/core/ThemePalette.qml
@@ -25,7 +25,7 @@ QtObject {
 
     property bool light
 
-    readonly property color textColor: light ? shade(0.7) : shade(1)
+    readonly property color textColor: light ? shade(0.87) : shade(1)
     readonly property color subTextColor: light ? shade(0.54) : shade(0.70)
     readonly property color iconColor: light ? subTextColor : textColor
     readonly property color disabledColor: light ? shade(0.38) : shade(0.50)


### PR DESCRIPTION
According to the [text and background colors specs](https://material.google.com/style/color.html#color-text-background-colors), primary dark text on light background should have an opacity of 87%, not 70%.

![text and background colors specs](https://i.imgur.com/5VHPrYw.png)
