### PR TITLE
Remove circle.png

### DIFF
--- a/src/extras/extras.qrc
+++ b/src/extras/extras.qrc
@@ -7,7 +7,6 @@
 	<file>CircleMask.qml</file>
 	<file>ColumnFlow.qml</file>
 	<file>Image.qml</file>
-	<file>circle.png</file>
 	<file>qmldir</file>
 </qresource>
 


### PR DESCRIPTION
Material fails to build because extras.qrc contains a reference to a missing file. This removes the reference
