### PR TITLE
demo: Fix the problem of "Material" is not installed

### DIFF
--- a/demo/demo.pro
+++ b/demo/demo.pro
@@ -4,3 +4,6 @@ QT += qml quick
 
 SOURCES += main.cpp
 RESOURCES += demo.qrc icons/icons.qrc
+
+DEFINES += QPM_INIT\\(E\\)=\"E.addImportPath(QStringLiteral(\\\"qrc:/\\\"));\"
+include(../material.pri)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -5,7 +5,9 @@ int main(int argc, char *argv[])
 {
     QGuiApplication app(argc, argv);
 
-    QQmlApplicationEngine engine(QUrl(QStringLiteral("qrc:/main.qml")));
+    QQmlApplicationEngine engine;
+    QPM_INIT(engine);
+    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
 
     return app.exec();
 }


### PR DESCRIPTION
This patch fix the runtime problem of "Material" is not installed for demo program

```
QQmlApplicationEngine failed to load component
qrc:/main.qml:3 module "Material.ListItems" is not installed
qrc:/main.qml:2 module "Material" is not installed
qrc:/main.qml:3 module "Material.ListItems" is not installed
qrc:/main.qml:2 module "Material" is not installed
```
